### PR TITLE
Multi-Select Support for <select>

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -284,7 +284,7 @@ class Html
 
         return Select::create()
             ->attribute('multiple')
-            ->attributeIf($name, 'name', $this->fieldName($name) . '[]')
+            ->attributeIf($name, 'name', $this->fieldName($name).'[]')
             ->attributeIf($name, 'id', $this->fieldName($name))
             ->addChildren($options, function ($text, $value) use ($values) {
                 return Option::create()

--- a/src/Html.php
+++ b/src/Html.php
@@ -280,9 +280,11 @@ class Html
      */
     public function multiselect(string $name = '', iterable $options = [], iterable $values = [])
     {
+        $values = $name ? $this->old($name, $values) : [];
+
         return Select::create()
             ->attribute('multiple')
-            ->attributeIf($name, 'name', $this->fieldName($name))
+            ->attributeIf($name, 'name', $this->fieldName($name) . '[]')
             ->attributeIf($name, 'id', $this->fieldName($name))
             ->addChildren($options, function ($text, $value) use ($values) {
                 return Option::create()
@@ -407,7 +409,7 @@ class Html
      *
      * @return mixed
      */
-    protected function old(string $name, ?string $value = '')
+    protected function old(string $name, $value = '')
     {
         if (empty($name)) {
             return;

--- a/src/Html.php
+++ b/src/Html.php
@@ -273,6 +273,26 @@ class Html
     }
 
     /**
+     * @param string $name
+     * @param iterable $options
+     * @param iterable $values
+     * @return \Spatie\Html\Elements\Select
+     */
+    public function multiselect(string $name = '', iterable $options = [], iterable $values = [])
+    {
+        return Select::create()
+            ->attribute('multiple')
+            ->attributeIf($name, 'name', $this->fieldName($name))
+            ->attributeIf($name, 'id', $this->fieldName($name))
+            ->addChildren($options, function ($text, $value) use ($values) {
+                return Option::create()
+                    ->value($value)
+                    ->text($text)
+                    ->selectedIf(in_array($value, $values));
+            });
+    }
+
+    /**
      * @param \Spatie\Html\HtmlElement|string $contents
      *
      * @return \Spatie\Html\Elements\Span

--- a/tests/Html/MultiSelectTest.php
+++ b/tests/Html/MultiSelectTest.php
@@ -22,7 +22,7 @@ class MultiSelectTest extends TestCase
         ];
 
         $this->assertHtmlStringEqualsHtmlString(
-            '<select name="select" id="select" multiple>
+            '<select name="select[]" id="select" multiple>
                 <option value="value1">text1</option>
                 <option value="value2">text2</option>
             </select>',
@@ -40,7 +40,7 @@ class MultiSelectTest extends TestCase
         ];
 
         $this->assertHtmlStringEqualsHtmlString(
-            '<select name="select" id="select" multiple>
+            '<select name="select[]" id="select" multiple>
                 <option value="value1" selected="selected">text1</option>
                 <option value="value2">text2</option>
                 <option value="value3" selected="selected">text3</option>

--- a/tests/Html/MultiSelectTest.php
+++ b/tests/Html/MultiSelectTest.php
@@ -5,7 +5,7 @@ namespace Spatie\Html\Test\Html;
 class MultiSelectTest extends TestCase
 {
     /** @test */
-    public function it_can_render_a_select_element()
+    public function it_can_render_a_multiple_select_element()
     {
         $this->assertHtmlStringEqualsHtmlString(
             '<select multiple></select>',
@@ -14,7 +14,7 @@ class MultiSelectTest extends TestCase
     }
 
     /** @test */
-    public function it_can_render_a_select_element_with_options()
+    public function it_can_render_a_multiple_select_element_with_options()
     {
         $options = [
             'value1' => 'text1',
@@ -31,7 +31,7 @@ class MultiSelectTest extends TestCase
     }
 
     /** @test */
-    public function it_can_render_a_select_element_with_multiple_options_selected()
+    public function it_can_render_a_multiple_select_element_with_options_selected()
     {
         $options = [
             'value1' => 'text1',

--- a/tests/Html/MultiSelectTest.php
+++ b/tests/Html/MultiSelectTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\Html\Test\Html;
+
+class MultiSelectTest extends TestCase
+{
+    /** @test */
+    public function it_can_render_a_select_element()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select multiple></select>',
+            $this->html->multiselect()->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_render_a_select_element_with_options()
+    {
+        $options = [
+            'value1' => 'text1',
+            'value2' => 'text2',
+        ];
+
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select name="select" id="select" multiple>
+                <option value="value1">text1</option>
+                <option value="value2">text2</option>
+            </select>',
+            $this->html->multiselect('select', $options)->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_render_a_select_element_with_multiple_options_selected()
+    {
+        $options = [
+            'value1' => 'text1',
+            'value2' => 'text2',
+            'value3' => 'text3',
+        ];
+
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select name="select" id="select" multiple>
+                <option value="value1" selected="selected">text1</option>
+                <option value="value2">text2</option>
+                <option value="value3" selected="selected">text3</option>
+            </select>',
+            $this->html->multiselect('select', $options, ['value1', 'value3'])->render()
+        );
+    }
+}

--- a/tests/Html/OldTest.php
+++ b/tests/Html/OldTest.php
@@ -37,4 +37,23 @@ class OldTest extends TestCase
                 $this->html->text('name')
             );
     }
+
+    /** @test */
+    public function it_supports_array_values_from_the_session()
+    {
+        $this
+            ->withSession(['name' => ['Freek', 'Sebastian']])
+            ->assertHtmlStringEqualsHtmlString(
+                '<select name="name[]" id="name" multiple>
+                    <option value="Freek" selected="selected">Freek</option>
+                    <option value="John">John</option>
+                    <option value="Sebastian" selected="selected">Sebastian</option>
+                </select>',
+                $this->html->multiselect('name', [
+                    'Freek' => 'Freek',
+                    'John' => 'John',
+                    'Sebastian' => 'Sebastian',
+                ])
+            );
+    }
 }


### PR DESCRIPTION
Provides `<select multiple/>` support. I wanted to get your thoughts on gathering model data. Right now type-hinting prevents being able to pass an array value to `Html::old()`. I wanted to get your feedback and not start another type-hinting holy war 😄 

![screen shot 2017-05-30 at 1 37 27 pm](https://cloud.githubusercontent.com/assets/177773/26603852/281aa4e4-453d-11e7-97dd-10454bfb1cb1.png)

![screen shot 2017-05-30 at 1 37 59 pm](https://cloud.githubusercontent.com/assets/177773/26603869/3ae00736-453d-11e7-805d-66954a8cd51e.png)

The code change triggering the above error is:

```php
public function multiselect(string $name = '', iterable $options = [], iterable $values = [])
{
    $values = $name ? $this->old($name, $values) : [];
    // ...
}
```

### Todo

- [ ] The `Html::old()` method is type-hinted as a nullable string, but old data from a multi-select will be an array. I want to get your opinion of how to deal with it.
- [x] The name attribute needs to support arrays

Closes #7 