### PR TITLE
Implement support for multiple select

### DIFF
--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -2,9 +2,9 @@
 
 namespace Spatie\Html\Elements;
 
-use Illuminate\Support\Collection;
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
+use Illuminate\Support\Collection;
 
 class Select extends BaseElement
 {
@@ -69,7 +69,7 @@ class Select extends BaseElement
      *
      * @return static
      */
-    public function value($value)
+    public function value($value = null)
     {
         $element = clone $this;
 

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -5,6 +5,7 @@ namespace Spatie\Html\Elements;
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class Select extends BaseElement
 {
@@ -22,7 +23,15 @@ class Select extends BaseElement
      */
     public function multiple()
     {
-        $element = $this->attribute('multiple');
+        $element = clone $this;
+
+        $element = $element->attribute('multiple');
+
+        $name = $element->getAttribute('name');
+
+        if ($name && ! Str::endsWith($name, '[]')) {
+            $element = $element->name($name . '[]');
+        }
 
         $element->applyValueToOptions();
 

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\Html\Elements;
 
+use Illuminate\Support\Str;
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 
 class Select extends BaseElement
 {
@@ -30,7 +30,7 @@ class Select extends BaseElement
         $name = $element->getAttribute('name');
 
         if ($name && ! Str::endsWith($name, '[]')) {
-            $element = $element->name($name . '[]');
+            $element = $element->name($name.'[]');
         }
 
         $element->applyValueToOptions();

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Html\Elements;
 
+use Illuminate\Support\Collection;
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
 
@@ -13,8 +14,20 @@ class Select extends BaseElement
     /** @var array */
     protected $options = [];
 
-    /** @var string */
+    /** @var string|iterable */
     protected $value = '';
+
+    /**
+     * @return static
+     */
+    public function multiple()
+    {
+        $element = $this->attribute('multiple');
+
+        $element->applyValueToOptions();
+
+        return $element;
+    }
 
     /**
      * @param string $name
@@ -52,11 +65,11 @@ class Select extends BaseElement
     }
 
     /**
-     * @param string $value
+     * @param string|iterable $value
      *
      * @return static
      */
-    public function value(?string $value)
+    public function value($value)
     {
         $element = clone $this;
 
@@ -74,9 +87,15 @@ class Select extends BaseElement
 
     protected function applyValueToOptions()
     {
-        $this->children = $this->children->map(function ($child) {
+        $value = Collection::make($this->value);
+
+        if (! $this->hasAttribute('multiple')) {
+            $value = $value->take(1);
+        }
+
+        $this->children = $this->children->map(function ($child) use ($value) {
             if ($child instanceof Selectable) {
-                return $child->selectedIf($this->value === $child->getAttribute('value'));
+                return $child->selectedIf($value->contains($child->getAttribute('value')));
             }
 
             return $child;

--- a/src/Html.php
+++ b/src/Html.php
@@ -269,7 +269,7 @@ class Html
             ->attributeIf($name, 'name', $this->fieldName($name))
             ->attributeIf($name, 'id', $this->fieldName($name))
             ->options($options)
-            ->value($name ? $this->old($name, $value) : '');
+            ->value($name ? $this->old($name, $value) : $value);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -259,11 +259,11 @@ class Html
     /**
      * @param string $name
      * @param iterable $options
-     * @param string $value
+     * @param string|iterable $value
      *
      * @return \Spatie\Html\Elements\Select
      */
-    public function select(string $name = '', iterable $options = [], ?string $value = '')
+    public function select(string $name = '', iterable $options = [], $value = '')
     {
         return Select::create()
             ->attributeIf($name, 'name', $this->fieldName($name))
@@ -384,10 +384,11 @@ class Html
 
     /**
      * @param string $name
+     * @param mixed  $value
      *
      * @return mixed
      */
-    protected function old(string $name, ?string $value = '')
+    protected function old(string $name, $value = '')
     {
         if (empty($name)) {
             return;

--- a/src/Html.php
+++ b/src/Html.php
@@ -388,7 +388,7 @@ class Html
      *
      * @return mixed
      */
-    protected function old(string $name, $value = '')
+    protected function old(string $name, $value = null)
     {
         if (empty($name)) {
             return;

--- a/tests/Elements/SelectTest.php
+++ b/tests/Elements/SelectTest.php
@@ -92,6 +92,23 @@ class SelectTest extends TestCase
     }
 
     /** @test */
+    public function it_can_convert_multiple_select_name()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select multiple="multiple" name="foo[]">
+                <option value="value1">text1</option>
+                <option value="value2">text2</option>
+                <option value="value3">text3</option>
+            </select>',
+            Select::create()
+                  ->name('foo')
+                  ->options(['value1' => 'text1', 'value2' => 'text2', 'value3' => 'text3'])
+                  ->multiple()
+                  ->render()
+        );
+    }
+
+    /** @test */
     public function it_can_have_multiple_values()
     {
         $this->assertHtmlStringEqualsHtmlString(

--- a/tests/Elements/SelectTest.php
+++ b/tests/Elements/SelectTest.php
@@ -74,4 +74,54 @@ class SelectTest extends TestCase
                 ->render()
         );
     }
+
+    /** @test */
+    public function it_can_have_a_multiple_option()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select multiple="multiple">
+                <option value="value1">text1</option>
+                <option value="value2">text2</option>
+                <option value="value3">text3</option>
+            </select>',
+            Select::create()
+                  ->options(['value1' => 'text1', 'value2' => 'text2', 'value3' => 'text3'])
+                  ->multiple()
+                  ->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_have_multiple_values()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select multiple="multiple">
+                <option value="value1" selected="selected">text1</option>
+                <option value="value2">text2</option>
+                <option value="value3" selected="selected">text3</option>
+            </select>',
+            Select::create()
+                  ->options(['value1' => 'text1', 'value2' => 'text2', 'value3' => 'text3'])
+                  ->value(['value1', 'value3'])
+                  ->multiple()
+                  ->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_have_one_multiple_value()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select multiple="multiple">
+                <option value="value1">text1</option>
+                <option value="value2">text2</option>
+                <option value="value3" selected="selected">text3</option>
+            </select>',
+            Select::create()
+                  ->options(['value1' => 'text1', 'value2' => 'text2', 'value3' => 'text3'])
+                  ->value('value3')
+                  ->multiple()
+                  ->render()
+        );
+    }
 }


### PR DESCRIPTION
Here's my take on implementing multiple select support (https://github.com/spatie/laravel-html/pull/20). I think it's cleaner to introduce a `multiple()` method on the `Select` class instead of creating `multiselect()` in the `Html` class.

Some explanation:
* the `applyValueToOptions()` method is modified to always compare against a collection.
* In case of a single select, the collection will always contain one value to get expected behavior, even though multiple values were provided. 
* In case of a multiple select, the collection will just pass through and select all applicable options.
* Since creating a new `Select` using the `Html` class automatically calls `value()`, hence already setting the selected options to those of a single select, the `multiple()` method calls `applyValueToOptions()` once more to reapply the new state and preselect options according to the full value collection.
* Passing a single value or array-like values to a multi select will both just work.
* An additional bug has been solved in which the provided default value was not passed on when no name is supplied for the select:

    ```php
    ->value($name ? $this->old($name, $value) : '')
    ```
    to
    ```php
    ->value($name ? $this->old($name, $value) : $value)
    ```


As can be seen, some type-hints including one of the `old()` method were removed to accommodate multiple default values. 
To be honest, I don't really get why a string type-hint was introduced to the `old()` method `$value` parameter since the underlying Request class also doesn't impose any restrictions to the default returned value... So to me this seems like an unwanted design flaw and code in your projects ([ref](https://github.com/spatie/laravel-html/pull/20#issuecomment-306578795)) should probably be rectified. If you don't feel up to removing the type-hint, you could consider changing the `select()` method as follows:

```php
/**
  * @param string $name
  * @param iterable $options
  * @param string|iterable $value
  *
  * @return \Spatie\Html\Elements\Select
  */
public function select(string $name = '', iterable $options = [], $value = '')
{
    if ($name) {
        // Omit string type-hint to support array-like $value.
        $value = is_null($this->old($name)) ? $value : $this->old($name);
    }

    return Select::create()
        ->attributeIf($name, 'name', $this->fieldName($name))
        ->attributeIf($name, 'id', $this->fieldName($name))
        ->options($options)
        ->value($value);
}
```