### PR TITLE
Allow form to be linked to a route

### DIFF
--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -38,4 +38,15 @@ class Form extends BaseElement
     {
         return $this->attribute('enctype', 'multipart/form-data');
     }
+
+    /**
+     * @param string $route
+     * @param array $parameters
+     *
+     * @return static
+     */
+    public function route($route, $parameters = [])
+    {
+        return $this->action(app('url')->route($route, $parameters));
+    }
 }


### PR DESCRIPTION
Something I always used in `laravelcollective/html` was the ability to define a route for a form, rather than the absolute URI.