### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/http": "~5.4",
-        "illuminate/support": "~5.4"
+        "illuminate/http": "~5.4|~5.5.x-dev",
+        "illuminate/support": "~5.4|~5.5.x-dev"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.7",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/http": "~5.4|~5.5.x-dev",
-        "illuminate/support": "~5.4|~5.5.x-dev"
+        "illuminate/http": "~5.4|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.4|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.7",
@@ -60,3 +60,4 @@
         }
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-html/phpunit.xml.dist

...............................................................  63 / 118 ( 53%)
.......................................................         118 / 118 (100%)

Time: 2.34 seconds, Memory: 12.00MB

OK (118 tests, 130 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments