### PR TITLE
add convenient data method

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -166,6 +166,17 @@ abstract class BaseElement implements Htmlable, HtmlElement
     }
 
     /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return static
+     */
+    public function data($name, $value)
+    {
+        return $this->attribute("data-{$name}", $value);
+    }
+
+    /**
      * @param \Spatie\Html\HtmlElement|string|iterable|null $children
      * @param callable|null $mapper
      *

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -348,6 +348,15 @@ class BaseElementTest extends TestCase
     {
         return Div::create()->text($text);
     }
+
+    /** @test */
+    public function it_can_set_a_data_attribute()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<div data-foo="bar"></div>',
+            Div::create()->data('foo', 'bar')->render()
+        );
+    }
 }
 
 class Div extends BaseElement


### PR DESCRIPTION
This PR adds a convenient `->data()` method to `BaseElement`.

```blade
{{ html()->div()->data('foo', 'bar') }}
```
which will be rendered as
```html
<div data-foo="bar"></div>
```