### PR TITLE
If all the things

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -2,12 +2,12 @@
 
 namespace Spatie\Html;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
-use Illuminate\Support\Traits\Macroable;
 use Spatie\Html\Exceptions\MissingTag;
 use Spatie\Html\Exceptions\InvalidHtml;
+use Illuminate\Support\Traits\Macroable;
 use Spatie\Html\Exceptions\InvalidChild;
 use Illuminate\Contracts\Support\Htmlable;
 
@@ -380,7 +380,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
 
     /**
      * Dynamically handle calls to the class.
-     * Check for methods finishing by If or fallback to Macroable
+     * Check for methods finishing by If or fallback to Macroable.
      *
      * @param  string  $method
      * @param  array   $parameters

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Html;
 
-use Illuminate\Support\Str;
+use BadMethodCallException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Spatie\Html\Exceptions\MissingTag;
@@ -386,24 +386,24 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * @param  array   $parameters
      * @return mixed
      *
-     * @throws \BadMethodCallException
+     * @throws BadMethodCallException
      */
     public function __call($name, $arguments)
     {
-        if (Str::endsWith($name, 'If')) {
-            $name = str_replace('If', '', $name);
+        if (ends_with($name, 'If')) {
+            $name = str_before($name, 'If');
             if (! method_exists($this, $name)) {
-                throw new \BadMethodCallException("$name is not a valid method for this class");
+                throw new BadMethodCallException("$name is not a valid method for this class");
             }
 
             $condition = (bool) array_shift($arguments);
-            
+
             return $condition ?
                 $this->{$name}(...$arguments) :
                 $this;
         }
 
-        return __macro_call($name, ...$arguments);
+        return $this->__macro_call($name, ...$arguments);
     }
 
     public function __clone()

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -391,7 +391,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     public function __call($name, $arguments)
     {
         if (ends_with($name, 'If')) {
-            $name = str_before($name, 'If');
+            $name = str_replace('If', '', $name);
             if (! method_exists($this, $name)) {
                 throw new BadMethodCallException("$name is not a valid method for this class");
             }

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -397,6 +397,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
             }
 
             $condition = (bool) array_shift($arguments);
+            
             return $condition ?
                 $this->{$name}(...$arguments) :
                 $this;

--- a/src/Elements/A.php
+++ b/src/Elements/A.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class A extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'a';
 
     /**

--- a/src/Elements/Button.php
+++ b/src/Elements/Button.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Button extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'button';
 
     /**

--- a/src/Elements/Div.php
+++ b/src/Elements/Div.php
@@ -3,11 +3,8 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Div extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'div';
 }

--- a/src/Elements/Element.php
+++ b/src/Elements/Element.php
@@ -6,12 +6,9 @@ use ReflectionClass;
 use Spatie\Html\Attributes;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Traits\Macroable;
 
 class Element extends BaseElement
 {
-    use Macroable;
-
     /**
      * @param string $tag
      *

--- a/src/Elements/Fieldset.php
+++ b/src/Elements/Fieldset.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Fieldset extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'fieldset';
 
     /**

--- a/src/Elements/File.php
+++ b/src/Elements/File.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class File extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'input';
 
     const ACCEPT_AUDIO = 'audio/*';

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Form extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'form';
 
     /**

--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Input extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'input';
 
     /**

--- a/src/Elements/Label.php
+++ b/src/Elements/Label.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Label extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'label';
 
     /**

--- a/src/Elements/Legend.php
+++ b/src/Elements/Legend.php
@@ -3,11 +3,8 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Legend extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'legend';
 }

--- a/src/Elements/Optgroup.php
+++ b/src/Elements/Optgroup.php
@@ -3,12 +3,9 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Optgroup extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'optgroup';
 
     /**

--- a/src/Elements/Option.php
+++ b/src/Elements/Option.php
@@ -4,12 +4,9 @@ namespace Spatie\Html\Elements;
 
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Option extends BaseElement implements Selectable
 {
-    use Macroable;
-
     /** @var string */
     protected $tag = 'option';
 

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -6,12 +6,9 @@ use Illuminate\Support\Str;
 use Spatie\Html\Selectable;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Traits\Macroable;
 
 class Select extends BaseElement
 {
-    use Macroable;
-
     /** @var string */
     protected $tag = 'select';
 

--- a/src/Elements/Span.php
+++ b/src/Elements/Span.php
@@ -3,11 +3,8 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Span extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'span';
 }

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -3,7 +3,6 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
-use Illuminate\Support\Traits\Macroable;
 
 class Textarea extends BaseElement
 {

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Traits\Macroable;
 
 class Textarea extends BaseElement
 {
-    use Macroable;
-
     protected $tag = 'textarea';
 
     /**

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Html\Test;
 
+use BadMethodCallException;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
 use Spatie\Html\Exceptions\MissingTag;
@@ -75,7 +76,7 @@ class BaseElementTest extends TestCase
     /** @test */
     public function it_can_not_accept_any_if_method()
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         Div::create()->barIf(true, 'bar')->render();
     }

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -64,6 +64,23 @@ class BaseElementTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_an_class_with_class_if()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<div class="bar"></div>',
+            Div::create()->classIf(true, 'bar')->classIf(false, 'baz')->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_not_accept_any_if_method()
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        Div::create()->barIf(true, 'bar')->render();
+    }
+
+    /** @test */
     public function it_can_forget_an_attribute()
     {
         $this->assertHtmlStringEqualsHtmlString(


### PR DESCRIPTION
![1xf4n5](https://user-images.githubusercontent.com/235510/31444276-0a9ea7b2-ae9c-11e7-96c8-87bc253a3cb1.jpg)

With this PR, every single method of `BaseElement` (and children) have a `if` version.

```php
html()->span()
      ->styleIf($hidden, 'display: none')
      ->classIf($class_name !== null, $class)
```

This will allow to lighten the html code generated (and/or the logic in the blade file).
Ofc `BaseElement::attributeIf` is removed here

Tests are provided (and existing `attributeIf` still pass)