### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "~5.4"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.7",
+        "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).