### PR TITLE
Allow input to populate value with `0` successfully

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -135,7 +135,7 @@ class Html
      */
     public function input($type = null, $name = null, $value = null)
     {
-        $hasValue = $name && ($this->old($name, $value) || ! is_null($value));
+        $hasValue = $name && (! is_null($this->old($name, $value)) || ! is_null($value));
 
         return Input::create()
             ->attributeIf($type, 'type', $type)

--- a/tests/Html/OldTest.php
+++ b/tests/Html/OldTest.php
@@ -13,6 +13,13 @@ class OldTest extends TestCase
                 '<input type="text" name="name" id="name" value="Sebastian">',
                 $this->html->text('name')
             );
+
+        $this
+            ->withSession(['number' => 0])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="number" name="number" id="number" value="0">',
+                $this->html->input('number', 'number')
+            );
     }
 
     /** @test */
@@ -30,6 +37,13 @@ class OldTest extends TestCase
             ->assertHtmlStringEqualsHtmlString(
                 '<input type="email" name="email" id="email" value="sebastian@spatie.be">',
                 $this->html->email('email')
+            );
+
+        $this
+            ->withModel(['number' => 0])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="number" name="number" id="number" value="0">',
+                $this->html->input('number', 'number')
             );
     }
 


### PR DESCRIPTION
Special case when a field value is `0`. Added tests for both sessions and models.