### PR TITLE
Use setChildren() when calling html() on an element

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -296,11 +296,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
             throw new InvalidHtml("Can't set inner contents on `{$this->tag}` because it's a void element");
         }
 
-        $element = clone $this;
-
-        $element->children = new Collection([$html]);
-
-        return $element;
+        return $this->setChildren($html);
     }
 
     /**

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -3,9 +3,9 @@
 namespace Spatie\Html\Test;
 
 use BadMethodCallException;
-use Illuminate\Support\HtmlString;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
 use Spatie\Html\Exceptions\MissingTag;
 use Spatie\Html\Exceptions\InvalidHtml;
 use Spatie\Html\Exceptions\InvalidChild;

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\Html\Test;
 
 use BadMethodCallException;
+use Illuminate\Support\HtmlString;
 use Spatie\Html\BaseElement;
 use Illuminate\Support\Collection;
 use Spatie\Html\Exceptions\MissingTag;
@@ -178,6 +179,15 @@ class BaseElementTest extends TestCase
         $this->assertHtmlStringEqualsHtmlString(
             '<div><span>Yo</span></div>',
             Div::create()->html('<span>Yo</span>')->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_set_html_from_htmlstring()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<div><span>Yo</span></div>',
+            Div::create()->html(new HtmlString('<span>Yo</span>'))->render()
         );
     }
 


### PR DESCRIPTION
An interesting case I came across recently. In a blade component, I set a submit button:

    {{ html()->submit($slot)->class('btn btn-primary') }}
    
which allows me to set the button text in another blade file as HTML (rather than a string):

    @component('layout.forms.submit')
        <span class="fa fa-plus" aria-hidden="true"></span> Add user
    @endcomponent

However, `$slot` is passed as `Illuminate\Support\HtmlString` to `BaseElement::html()`. Previously the `html()` function would add this blindly to the children array, and then rendering would fail when it encountered the `HtmlString`.

Calling `setChildren()` from `html()` converts the `HtmlString` to a string that can be handled correctly.