### PR TITLE
Fix checkbox values

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -95,7 +95,7 @@ class Html
             ->attribute('type', 'checkbox')
             ->attributeIf($name, 'name', $this->fieldName($name))
             ->attributeIf($name, 'id', $this->fieldName($name))
-            ->attributeIf(!is_null($value), 'value', $value)
+            ->attributeIf(! is_null($value), 'value', $value)
             ->attributeIf((bool) $this->old($name, $checked), 'checked');
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -91,7 +91,11 @@ class Html
      */
     public function checkbox($name = null, $checked = false, $value = '1')
     {
-        return $this->input('checkbox', $name, $value)
+        return Input::create()
+            ->attribute('type', 'checkbox')
+            ->attributeIf($name, 'name', $this->fieldName($name))
+            ->attributeIf($name, 'id', $this->fieldName($name))
+            ->attributeIf(!is_null($value), 'value', $value)
             ->attributeIf((bool) $this->old($name, $checked), 'checked');
     }
 

--- a/tests/Html/CheckboxTest.php
+++ b/tests/Html/CheckboxTest.php
@@ -8,7 +8,7 @@ class CheckboxTest extends TestCase
     public function it_can_create_a_checkbox()
     {
         $this->assertHtmlStringEqualsHtmlString(
-            '<input type="checkbox">',
+            '<input type="checkbox" value="1">',
             $this->html->checkbox()
         );
     }


### PR DESCRIPTION
The checkbox input should not pull its _value_ from old/session input - that should only affect whether it is _checked_.

An example: we are displaying a boolean value as a checkbox. The boolean is stored as 0 or 1 in the model. If the boolean is currently 0, then the checkbox will be generated as:
    
    <input type="checkbox" name="name" id="name" value="0">

When this form is posted with the checkbox checked, `name` will be set to `0`... which may be interpreted as false. In this case, the boolean can never be set to true again.

I believe this behaviour started after PR #69 was merged.