### PR TITLE
Update dependencies for Laravel 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/http": "~5.4.0|~5.5.0",
-        "illuminate/support": "~5.4.0|~5.5.0"
+        "illuminate/http": "~5.4.0|~5.5.0|~5.6.0",
+        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
https://github.com/spatie/laravel-html/blob/55a367862d61a46620bc04ec1dd2ae24c16c470e/composer.json#L27

Upgraded my project to Laravel 5.6, but spatie/laravel-html won't come along 😊 Dependencies for 2.12 are still locked at 5.4 and 5.5.

This should fix it:

```
    "require": {
        "php": "^7.0",
        "illuminate/http": "~5.4.0|~5.5.0|~5.6.0",
        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0"
    },
```

Also an option is to just depend on the minimum version:

https://github.com/sebastiaanluca/laravel-router/blob/master/composer.json#L24

This allows your package to be used in any version upwards of the minimum requirement, without having to upgrade whenever a new release comes out. Of course, it can happen something breaks, but since it can be used ahead of time, users can notify you of this in advance.