### PR TITLE
Add date and time convenience methods

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -121,6 +121,28 @@ class Html
     }
 
     /**
+     * @param string|null $name
+     * @param string|null $value
+     *
+     * @return \Spatie\Html\Elements\Input
+     */
+    public function date($name = '', $value = '')
+    {
+        return $this->input('date', $name, $value);
+    }
+
+    /**
+     * @param string|null $name
+     * @param string|null $value
+     *
+     * @return \Spatie\Html\Elements\Input
+     */
+    public function time($name = '', $value = '')
+    {
+        return $this->input('time', $name, $value);
+    }
+
+    /**
      * @param string $tag
      *
      * @return \Spatie\Html\Elements\Element

--- a/tests/Concerns/AssertsHtmlStrings.php
+++ b/tests/Concerns/AssertsHtmlStrings.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Html\Test\Concerns;
 
-use DOMElement;
 use DOMDocument;
 
 trait AssertsHtmlStrings

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -103,4 +103,22 @@ class InputTest extends TestCase
             $this->html->input()->readonly()
         );
     }
+
+    /** @test */
+    public function it_can_create_a_date_input()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="date">',
+            $this->html->date()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_time_input()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+                '<input type="time">',
+                $this->html->time()
+            );
+    }
 }


### PR DESCRIPTION
Adds input convenience methods for:

```html
<input type="date">
<input type="time">
```

I skipped `datetime-local` because browser support is far better for `date` and `time` so it's better to use that combo at the time of this PR 🥂 