### PR TITLE
Allow passing a boolean for making a field required.

### DIFF
--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -61,11 +61,15 @@ class Input extends BaseElement
     }
 
     /**
+     * @param bool $required
+     *
      * @return static
      */
-    public function required()
+    public function required($required = true)
     {
-        return $this->attribute('required');
+        return $required
+            ? $this->attribute('required')
+            : $this->forgetAttribute('required');
     }
 
     /**

--- a/tests/Elements/InputTest.php
+++ b/tests/Elements/InputTest.php
@@ -62,6 +62,24 @@ class InputTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_an_input_that_is_required_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input required>',
+            Input::create()->required(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_an_input_that_is_required_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input>',
+            Input::create()->required(false)
+        );
+    }
+
+    /** @test */
     public function it_can_create_an_input_that_has_autofocus()
     {
         $this->assertHtmlStringEqualsHtmlString(


### PR DESCRIPTION
This feature is already possible for marking an input as disabled, but not for the required attribute.

Instead of writing this:

```php
@if(true)
    {{ html()->input('name')->required() }}
@else
    {{ html()->input('name') }}
@endif
```

We can write it like this:

```php
{{ html()->input('name')->required(false) }}
```

which will not add the required attribute to the input.