### PR TITLE
Automatically prefill form array attributes from the model

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -500,14 +500,14 @@ class Html
             return;
         }
 
+        // Convert array format (sth[1]) to dot notation (sth.1)
+        $name = preg_replace('/\[(.+)\]/U', '.$1', $name);
+
         // If there's no default value provided, and the html builder currently
         // has a model assigned, try to retrieve a value from the model.
         if (empty($value) && $this->model) {
-            $value = $this->model[$name] ?? '';
+            $value = data_get($this->model, $name) ?? '';
         }
-
-        // Convert array format (sth[1]) to dot notation (sth.1)
-        $name = preg_replace('/\[(.+)\]/U', '.$1', $name);
 
         return $this->request->old($name, $value);
     }

--- a/tests/Html/OldTest.php
+++ b/tests/Html/OldTest.php
@@ -69,4 +69,62 @@ class OldTest extends TestCase
                 $this->html->text('name[1][a]')
             );
     }
+
+    /** @test */
+    public function it_returns_a_model_value_from_a_name_with_an_array_if_its_available_in_the_model()
+    {
+        $this
+            ->withModel(['name' => ['first_name' => 'Sebastian']])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="text" name="name[first_name]" id="name[first_name]" value="Sebastian">',
+                $this->html->text('name[first_name]')
+            );
+
+        $this
+            ->withModel(['relation' => ['name' => ['first_name' => 'Sebastian']]])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="text" name="relation[name][first_name]" id="relation[name][first_name]" value="Sebastian">',
+                $this->html->text('relation[name][first_name]')
+            );
+
+        $this
+            ->withModel(['contact' => ['email' => 'sebastian@spatie.be']])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="email" name="contact[email]" id="contact[email]" value="sebastian@spatie.be">',
+                $this->html->email('contact[email]')
+            );
+
+        $this
+            ->withModel(['relation' => ['contact' => ['email' => 'sebastian@spatie.be']]])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="email" name="relation[contact][email]" id="relation[contact][email]" value="sebastian@spatie.be">',
+                $this->html->email('relation[contact][email]')
+            );
+
+        $this
+            ->withModel(['order' => ['number' => 0]])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="number" name="order[number]" id="order[number]" value="0">',
+                $this->html->input('number', 'order[number]')
+            );
+
+        $this
+            ->withModel(['relation' => ['order' => ['number' => 0]]])
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="number" name="relation[order][number]" id="relation[order][number]" value="0">',
+                $this->html->input('number', 'relation[order][number]')
+            );
+    }
+
+    /** @test */
+    public function it_returns_a_session_value_from_a_name_with_an_array_if_its_available_in_the_model_and_the_session()
+    {
+        $this
+            ->withModel(['relation' => ['name' => ['first_name' => 'Freek']]])
+            ->withSession(array_dot(['relation' => ['name' => ['first_name' => 'Sebastian']]]))
+            ->assertHtmlStringEqualsHtmlString(
+                '<input type="text" name="relation[name][first_name]" id="relation[name][first_name]" value="Sebastian">',
+                $this->html->text('relation[name][first_name]')
+            );
+    }
 }


### PR DESCRIPTION
Say you've got some model attributes, but they're part of an array (maybe JSON) or a relation. Currently these aren't retrieved and prefilled when you're using a model to build your form.

E.g. an address model linked to the model you're using for the form:

```php
{{ html()->text('address[city]') }}
```

This PR makes use of `data_get()` to get the attribute using dot notation.

Need to add a test for this, but my local PHP setup is botched so I can't install any vendor packages. Need to get that sorted first, maybe you guys are faster ;)