### PR TITLE
Default to email address for mailto, fix failing test

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -278,7 +278,7 @@ class Html
      */
     public function mailto($email, $text = null)
     {
-        return $this->a('mailto:'.$email, $text);
+        return $this->a('mailto:'.$email, $text ?: $email);
     }
 
     /**

--- a/tests/Html/FormTest.php
+++ b/tests/Html/FormTest.php
@@ -42,7 +42,7 @@ class FormTest extends TestCase
         $this->html->form('DELETE', '/submit');
         $this->assertHtmlStringEqualsHtmlString(
             '<p>delete</p>',
-            $this->html->value('_method', 'DELETE')
+            $this->html->value('_method', 'delete')
         );
         $this->assertHtmlStringEqualsHtmlString(
             '<p>abc</p>',

--- a/tests/Html/MailToTest.php
+++ b/tests/Html/MailToTest.php
@@ -8,7 +8,7 @@ class MailToTest extends TestCase
     public function it_can_create_a_mailto_link()
     {
         $this->assertHtmlStringEqualsHtmlString(
-            '<a href="mailto:hello@example.com"></a>',
+            '<a href="mailto:hello@example.com">hello@example.com</a>',
             $this->html->mailto('hello@example.com')
         );
     }


### PR DESCRIPTION
Avoid need to pass email address twice to mailto().