### PR TITLE
Fix radio value with old inputs

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -105,10 +105,7 @@ class Html
      */
     public function checkbox($name = null, $checked = false, $value = '1')
     {
-        return Input::create()
-            ->attribute('type', 'checkbox')
-            ->attributeIf($name, 'name', $this->fieldName($name))
-            ->attributeIf($name, 'id', $this->fieldName($name))
+        return $this->input('checkbox', $name, $value)
             ->attributeIf(! is_null($value), 'value', $value)
             ->attributeIf((bool) $this->old($name, $checked), 'checked');
     }
@@ -334,6 +331,7 @@ class Html
     {
         return $this->input('radio', $name, $value)
             ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.str_slug($value)))
+            ->attributeIf(! is_null($value), 'value', $value)
             ->attributeIf((! is_null($value) && $this->old($name) == $value) || $checked, 'checked');
     }
 


### PR DESCRIPTION
After submit, all radio options have the “value” attribute populated with the value of selected option.

### Using
```php
{{ html()->radio('radio', null, 'value1') }}
{{ html()->radio('radio', null, 'value2') }}
{{ html()->radio('radio', null, 'value3') }}
```

### Result

```html
<input type="radio" name="radio" id="radio_value1" value="value1">
<input type="radio" name="radio" id="radio_value2" value="value2">
<input type="radio" name="radio" id="radio_value3" value="value3">
```

### Check the second radio and submit. This is the result with old inputs

```html
<input type="radio" name="radio" id="radio_value1" value="value2">
<input type="radio" name="radio" id="radio_value2" value="value2" checked="checked">
<input type="radio" name="radio" id="radio_value3" value="value2">
```

You can notice that all radio options now have the same value.