### PR TITLE
Adding the `unless` conditional method

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -421,10 +421,8 @@ abstract class BaseElement implements Htmlable, HtmlElement
         switch ($type) {
             case 'If':
                 return $this->if($condition, $callback);
-
             case 'Unless':
                 return $this->unless($condition, $callback);
-
             default:
                 return $this;
         }

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -300,19 +300,31 @@ abstract class BaseElement implements Htmlable, HtmlElement
     }
 
     /**
-     * Condintionally transform the element. Note that since elements are
+     * Conditionally transform the element. Note that since elements are
      * immutable, you'll need to return a new instance from the callback.
      *
      * @param bool $condition
-     * @param callable $callback
+     * @param \Closure $callback
+     *
+     * @return mixed
      */
-    public function if(bool $condition, callable $callback)
+    public function if(bool $condition, \Closure $callback)
     {
-        if ($condition) {
-            return $callback($this);
-        }
+        return $condition ? $callback($this) : $this;
+    }
 
-        return $this;
+    /**
+     * Conditionally transform the element. Note that since elements are
+     * immutable, you'll need to return a new instance from the callback.
+     *
+     * @param bool $condition
+     * @param \Closure $callback
+     *
+     * @return mixed
+     */
+    public function unless(bool $condition, \Closure $callback)
+    {
+        return $this->if(! $condition, $callback);
     }
 
     /**
@@ -378,28 +390,44 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * Dynamically handle calls to the class.
      * Check for methods finishing by If or fallback to Macroable.
      *
-     * @param  string  $method
-     * @param  array   $parameters
+     * @param  string  $name
+     * @param  array   $arguments
      * @return mixed
      *
      * @throws BadMethodCallException
      */
     public function __call($name, $arguments)
     {
-        if (ends_with($name, 'If')) {
-            $name = str_replace('If', '', $name);
-            if (! method_exists($this, $name)) {
-                throw new BadMethodCallException("$name is not a valid method for this class");
+        if (ends_with($name, $conditions = ['If', 'Unless'])) {
+            foreach ($conditions as $condition) {
+                if (! method_exists($this, $method = str_replace($condition, '', $name))) {
+                    continue;
+                }
+
+                return $this->callConditionalMethod($condition, $method, $arguments);
             }
-
-            $condition = (bool) array_shift($arguments);
-
-            return $condition ?
-                $this->{$name}(...$arguments) :
-                $this;
         }
 
         return $this->__macro_call($name, $arguments);
+    }
+
+    protected function callConditionalMethod($type, $method, array $arguments)
+    {
+        $condition = (bool) array_shift($arguments);
+        $callback = function () use ($method, $arguments) {
+            return $this->{$method}(...$arguments);
+        };
+
+        switch ($type) {
+            case 'If':
+                return $this->if($condition, $callback);
+
+            case 'Unless':
+                return $this->unless($condition, $callback);
+
+            default:
+                return $this;
+        }
     }
 
     public function __clone()

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -64,6 +64,11 @@ class BaseElementTest extends TestCase
             '<div foo="bar"></div>',
             Div::create()->attributeIf(true, 'foo', 'bar')->attributeIf(false, 'bar', 'baz')->render()
         );
+
+        $this->assertHtmlStringEqualsHtmlString(
+            '<div foo="bar"></div>',
+            Div::create()->attributeUnless(false, 'foo', 'bar')->attributeUnless(true, 'bar', 'baz')->render()
+        );
     }
 
     /** @test */
@@ -383,6 +388,16 @@ class BaseElementTest extends TestCase
                 return $div->addClass('foo');
             })
             ->if(false, function (Div $div) {
+                return $div->addClass('bar');
+            });
+
+        $this->assertHtmlStringEqualsHtmlString('<div class="foo"></div>', $div);
+
+        $div = Div::create()
+            ->unless(false, function (Div $div) {
+                return $div->addClass('foo');
+            })
+            ->unless(true, function (Div $div) {
                 return $div->addClass('bar');
             });
 


### PR DESCRIPTION
As described in the title, this feature adds the ability to reverse the `if()` method.

Example: 

```php
Div::create()->unless(false, function (Div $div) {
    return $div->addClass('foo');
});

// OR

Div::create()->attributeUnless(false, 'class', 'foo');
```

