### PR TITLE
Add null to data value

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -163,7 +163,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      *
      * @return static
      */
-    public function data($name, $value)
+    public function data($name, $value = null)
     {
         return $this->attribute("data-{$name}", $value);
     }


### PR DESCRIPTION
Sometimes I need to add a valueless data attribute, so it would be more interesting to leave the value optional to get simpler.

```blade
{{ html()->hidden('example')->data('example', null) }}
-> <input type="hidden" name="example" id="example" example>
vs
{{ html()->hidden('example')->data('example') }}
-> <input type="hidden" name="example" id="example" example>
```