### PR TITLE
add datetime method to support datetime-local

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -171,7 +171,7 @@ class Html
         }
 
         return $element->value($this->formatDateTime($element->getAttribute('value'),
-            self::HTML_DATE_FORMAT . "T". self::HTML_TIME_FORMAT));
+            self::HTML_DATE_FORMAT."T".self::HTML_TIME_FORMAT));
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -171,7 +171,7 @@ class Html
         }
 
         return $element->value($this->formatDateTime($element->getAttribute('value'),
-            self::HTML_DATE_FORMAT . "T". self::HTML_DATE_FORMAT));
+            self::HTML_DATE_FORMAT . "T". self::HTML_TIME_FORMAT));
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -171,7 +171,7 @@ class Html
         }
 
         return $element->value($this->formatDateTime($element->getAttribute('value'),
-            self::HTML_DATE_FORMAT."T".self::HTML_TIME_FORMAT));
+            self::HTML_DATE_FORMAT.'T'.self::HTML_TIME_FORMAT));
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -158,6 +158,25 @@ class Html
     /**
      * @param string|null $name
      * @param string|null $value
+     * @param bool $format
+     *
+     * @return \Spatie\Html\Elements\Input
+     */
+    public function datetime($name = '', $value = null, $format = true)
+    {
+        $element = $this->input('datetime-local', $name, $value);
+
+        if (! $format || empty($element->getAttribute('value'))) {
+            return $element;
+        }
+
+        return $element->value($this->formatDateTime($element->getAttribute('value'),
+            self::HTML_DATE_FORMAT . "T". self::HTML_DATE_FORMAT));
+    }
+
+    /**
+     * @param string|null $name
+     * @param string|null $value
      * @param string|null $min
      * @param string|null $max
      * @param string|null $step

--- a/src/Html.php
+++ b/src/Html.php
@@ -171,7 +171,7 @@ class Html
         }
 
         return $element->value($this->formatDateTime($element->getAttribute('value'),
-            self::HTML_DATE_FORMAT.'T'.self::HTML_TIME_FORMAT));
+            self::HTML_DATE_FORMAT.'\T'.self::HTML_TIME_FORMAT));
     }
 
     /**

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -152,6 +152,53 @@ class InputTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_datetime_input()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="datetime-local">',
+            $this->html->datetime()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_datetime_input_with_blank_date()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input id="test_datetime" name="test_datetime" type="datetime-local" value=""/>',
+            $this->html->datetime('test_datetime', '')
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_datetime_input_and_format_date()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input id="test_datetime" name="test_datetime" type="date" value="2020-01-20T15:00:12"/>',
+            $this->html->datetime('test_datetime', '2020-01-20T15:00:12')
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_date_input_and_format_model_date()
+    {
+        $this->html->model(['test_datetime' => '2020-01-20T15:00:12']);
+
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input id="test_datetime" name="test_datetime" type="datetime-local" value="2020-01-20T15:00:12"/>',
+            $this->html->date('test_datetime')
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_date_input_with_invalid_date()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input id="test_datetime" name="test_date" type="date" value="notadate"/>',
+            $this->html->datetime('test_datetime', 'notadate')
+        );
+    }
+
+    /** @test */
     public function it_can_create_a_time_input()
     {
         $this->assertHtmlStringEqualsHtmlString(

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -185,7 +185,7 @@ class InputTest extends TestCase
 
         $this->assertHtmlStringEqualsHtmlString(
             '<input id="test_datetime" name="test_datetime" type="datetime-local" value="2020-01-20T15:00:12"/>',
-            $this->html->date('test_datetime')
+            $this->html->datetime('test_datetime')
         );
     }
 
@@ -193,7 +193,7 @@ class InputTest extends TestCase
     public function it_can_create_a_datetime_input_with_invalid_date()
     {
         $this->assertHtmlStringEqualsHtmlString(
-            '<input id="test_datetime" name="test_date" type="datetime-local" value="notadate"/>',
+            '<input id="test_datetime" name="test_datetime" type="datetime-local" value="notadate"/>',
             $this->html->datetime('test_datetime', 'notadate')
         );
     }

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -173,7 +173,7 @@ class InputTest extends TestCase
     public function it_can_create_a_datetime_input_and_format_date()
     {
         $this->assertHtmlStringEqualsHtmlString(
-            '<input id="test_datetime" name="test_datetime" type="date" value="2020-01-20T15:00:12"/>',
+            '<input id="test_datetime" name="test_datetime" type="datetime-local" value="2020-01-20T15:00:12"/>',
             $this->html->datetime('test_datetime', '2020-01-20T15:00:12')
         );
     }
@@ -193,7 +193,7 @@ class InputTest extends TestCase
     public function it_can_create_a_datetime_input_with_invalid_date()
     {
         $this->assertHtmlStringEqualsHtmlString(
-            '<input id="test_datetime" name="test_date" type="date" value="notadate"/>',
+            '<input id="test_datetime" name="test_date" type="datetime-local" value="notadate"/>',
             $this->html->datetime('test_datetime', 'notadate')
         );
     }

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -179,7 +179,7 @@ class InputTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_date_input_and_format_model_date()
+    public function it_can_create_a_datetime_input_and_format_model_date()
     {
         $this->html->model(['test_datetime' => '2020-01-20T15:00:12']);
 
@@ -190,7 +190,7 @@ class InputTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_date_input_with_invalid_date()
+    public function it_can_create_a_datetime_input_with_invalid_date()
     {
         $this->assertHtmlStringEqualsHtmlString(
             '<input id="test_datetime" name="test_date" type="date" value="notadate"/>',


### PR DESCRIPTION
For ease of use, datetime-local should be supported by laravel-html. Date format differs from carbon default.