### PR TITLE
Add a flag to Input::readonly to toggle readonly-ness.

### DIFF
--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -101,11 +101,15 @@ class Input extends BaseElement
     }
 
     /**
+     * @param bool $readonly
+     *
      * @return static
      */
-    public function readonly()
+    public function readonly($readonly = true)
     {
-        return $this->attribute('readonly');
+        return $readonly
+            ? $this->attribute('readonly')
+            : $this->forgetAttribute('readonly');
     }
 
     /**

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -105,6 +105,24 @@ class InputTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_an_input_without_readonly()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input>',
+            $this->html->input()->readonly(false)
+        );
+    }
+
+    /** @test */
+    public function it_can_remove_readonly_from_a_readonly_input()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input>',
+            $this->html->input()->readonly()->readonly(false)
+        );
+    }
+
+    /** @test */
     public function it_can_create_a_date_input()
     {
         $this->assertHtmlStringEqualsHtmlString(


### PR DESCRIPTION
Currently `->readonly()` only sets readonly on inputs, as opposed to `->required()`, `->disabled()` and others which accept a bool to toggle the attribute on or off and allow for fluent chaining. This PR brings `->readonly()` in line with the others.