### PR TITLE
Normalise common attributes

### DIFF
--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -102,6 +102,7 @@ echo Element::withTag('p')->text('This is the content!');
 - `function optgroup(string $label, iterable $options)`
 - `function options(iterable $options)`
 - `function placeholder(?$text)`
+- `function readonly(?$readonly)`
 - `function required(?$required)`
 - `function value(?string $value)`
 

--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -40,7 +40,7 @@ echo Element::withTag('p')->text('This is the content!');
 - `function acceptAudio()`
 - `function acceptImage()`
 - `function acceptVideo()`
-- `function autofocus()`
+- `function autofocus(?$autofocus)`
 - `function multiple()`
 - `function name(?string $name)`
 - `function required()`
@@ -50,6 +50,8 @@ echo Element::withTag('p')->text('This is the content!');
 - `function action(?string $action)`
 - `function method(?string $method)`
 - `function acceptsFiles()`
+- `function novalidate($novalidate = true)`
+
 
 ## `I`
 
@@ -60,7 +62,7 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Input`
 
-- `function autofocus()`
+- `function autofocus(?$autofocus)`
 - `function checked($checked = true)`
 - `function disabled($disabled = true)`
 - `function name(?string $name)`
@@ -71,7 +73,8 @@ echo Element::withTag('p')->text('This is the content!');
 - `function type(?string $type)`
 - `function unchecked()`
 - `function value(?string $value)`
-
+- `function maxlength(int $maxlength)`
+- `function minlength(int $minlength)`
 
 ## `Label`
 
@@ -92,20 +95,29 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Select`
 
+- `function autofocus(?$autofocus)`
+- `function disabled(?$disabled)`
 - `function multiple()`
 - `function name(?string $name)`
 - `function optgroup(string $label, iterable $options)`
 - `function options(iterable $options)`
 - `function placeholder(?$text)`
-- `function required()`
+- `function required(?$required)`
 - `function value(?string $value)`
 
 ## `Span`
 
-## `TextArea`
+## `Textarea`
 
 - `function autofocus()`
+- `function cols(int $cols)`
+- `function disabled(?$disabled)`
+- `function maxlength(int $maxlength)`
+- `function minlength(int $minlength)`
 - `function name(?string $name)`
 - `function placeholder(?string $placeholder)`
+- `function readonly(?$readonly)`
 - `function required()`
+- `function required(?$required)`
+- `function rows(int $rows)`
 - `function value(?string $value)`

--- a/src/Elements/Attributes/Autofocus.php
+++ b/src/Elements/Attributes/Autofocus.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Autofocus
+{
+    /**
+     * @param bool $autofocus
+     *
+     * @return static
+     */
+    public function autofocus($autofocus = true)
+    {
+        return $autofocus
+            ? $this->attribute('autofocus')
+            : $this->forgetAttribute('autofocus');
+    }
+}

--- a/src/Elements/Attributes/Disabled.php
+++ b/src/Elements/Attributes/Disabled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Disabled
+{
+    /**
+     * @param bool $disabled
+     *
+     * @return static
+     */
+    public function disabled($disabled = true)
+    {
+        return $disabled
+            ? $this->attribute('disabled', 'disabled')
+            : $this->forgetAttribute('disabled');
+    }
+}

--- a/src/Elements/Attributes/MinMaxLength.php
+++ b/src/Elements/Attributes/MinMaxLength.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait MinMaxLength
+{
+    /**
+     * @param int $minlength
+     *
+     * @return static
+     */
+    public function minlength(int $minlength)
+    {
+        return $this->attribute('minlength', $minlength);
+    }
+
+    /**
+     * @param int $maxlength
+     *
+     * @return static
+     */
+    public function maxlength(int $maxlength)
+    {
+        return $this->attribute('maxlength', $maxlength);
+    }
+}

--- a/src/Elements/Attributes/Name.php
+++ b/src/Elements/Attributes/Name.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Name
+{
+    /**
+     * @param string $name
+     *
+     * @return static
+     */
+    public function name($name)
+    {
+        return $this->attribute('name', $name);
+    }
+}

--- a/src/Elements/Attributes/Placeholder.php
+++ b/src/Elements/Attributes/Placeholder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Placeholder
+{
+    /**
+     * @param string|null $placeholder
+     *
+     * @return static
+     */
+    public function placeholder($placeholder)
+    {
+        return $this->attribute('placeholder', $placeholder);
+    }
+}

--- a/src/Elements/Attributes/Readonly.php
+++ b/src/Elements/Attributes/Readonly.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Readonly
+{
+    /**
+     * @param bool $readonly
+     *
+     * @return static
+     */
+    public function readonly($readonly = true)
+    {
+        return $readonly
+            ? $this->attribute('readonly')
+            : $this->forgetAttribute('readonly');
+    }
+}

--- a/src/Elements/Attributes/Required.php
+++ b/src/Elements/Attributes/Required.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Required
+{
+    /**
+     * @param bool $required
+     *
+     * @return static
+     */
+    public function required($required = true)
+    {
+        return $required
+            ? $this->attribute('required')
+            : $this->forgetAttribute('required');
+    }
+}

--- a/src/Elements/Attributes/Type.php
+++ b/src/Elements/Attributes/Type.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Type
+{
+    /**
+     * @param string|null $type
+     *
+     * @return static
+     */
+    public function type($type)
+    {
+        return $this->attribute('type', $type);
+    }
+}

--- a/src/Elements/Attributes/Value.php
+++ b/src/Elements/Attributes/Value.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Html\Elements\Attributes;
+
+trait Value
+{
+    /**
+     * @param string|null $value
+     *
+     * @return static
+     */
+    public function value($value)
+    {
+        return $this->attribute('value', $value);
+    }
+}

--- a/src/Elements/Button.php
+++ b/src/Elements/Button.php
@@ -3,38 +3,15 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Type;
+use Spatie\Html\Elements\Attributes\Value;
 
 class Button extends BaseElement
 {
+    use Value;
+    use Name;
+    use Type;
+
     protected $tag = 'button';
-
-    /**
-     * @param string|null $type
-     *
-     * @return static
-     */
-    public function type($type)
-    {
-        return $this->attribute('type', $type);
-    }
-
-    /**
-     * @param string|null $value
-     *
-     * @return static
-     */
-    public function value($value)
-    {
-        return $this->attribute('value', $value);
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return static
-     */
-    public function name($name)
-    {
-        return $this->attribute('name', $name);
-    }
 }

--- a/src/Elements/File.php
+++ b/src/Elements/File.php
@@ -3,9 +3,16 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Autofocus;
+use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Required;
 
 class File extends BaseElement
 {
+    use Autofocus;
+    use Name;
+    use Required;
+
     protected $tag = 'input';
 
     const ACCEPT_AUDIO = 'audio/*';
@@ -17,32 +24,6 @@ class File extends BaseElement
         parent::__construct();
 
         $this->attributes->setAttribute('type', 'file');
-    }
-
-    /**
-     * @param string|null $name
-     *
-     * @return static
-     */
-    public function name($name)
-    {
-        return $this->attribute('name', $name);
-    }
-
-    /**
-     * @return static
-     */
-    public function required()
-    {
-        return $this->attribute('required');
-    }
-
-    /**
-     * @return static
-     */
-    public function autofocus()
-    {
-        return $this->attribute('autofocus');
     }
 
     /**

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -29,11 +29,15 @@ class Form extends BaseElement
     }
 
     /**
+     * @param bool $novalidate
+     *
      * @return static
      */
-    public function novalidate()
+    public function novalidate($novalidate = true)
     {
-        return $this->attribute('novalidate');
+        return $novalidate
+            ? $this->attribute('novalidate')
+            : $this->forgetAttribute('novalidate');
     }
 
     /**

--- a/src/Elements/Input.php
+++ b/src/Elements/Input.php
@@ -3,17 +3,36 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Autofocus;
+use Spatie\Html\Elements\Attributes\Disabled;
+use Spatie\Html\Elements\Attributes\MinMaxLength;
+use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Placeholder;
+use Spatie\Html\Elements\Attributes\Readonly;
+use Spatie\Html\Elements\Attributes\Required;
+use Spatie\Html\Elements\Attributes\Type;
+use Spatie\Html\Elements\Attributes\Value;
 
 class Input extends BaseElement
 {
+    use Autofocus;
+    use Disabled;
+    use MinMaxLength;
+    use Name;
+    use Placeholder;
+    use Readonly;
+    use Required;
+    use Type;
+    use Value;
+
     protected $tag = 'input';
 
     /**
      * @return static
      */
-    public function autofocus()
+    public function unchecked()
     {
-        return $this->attribute('autofocus');
+        return $this->checked(false);
     }
 
     /**
@@ -26,90 +45,6 @@ class Input extends BaseElement
         return $checked
             ? $this->attribute('checked', 'checked')
             : $this->forgetAttribute('checked');
-    }
-
-    /**
-     * @param bool $disabled
-     *
-     * @return static
-     */
-    public function disabled($disabled = true)
-    {
-        return $disabled
-            ? $this->attribute('disabled', 'disabled')
-            : $this->forgetAttribute('disabled');
-    }
-
-    /**
-     * @param string|null $name
-     *
-     * @return static
-     */
-    public function name($name)
-    {
-        return $this->attribute('name', $name);
-    }
-
-    /**
-     * @param string|null $placeholder
-     *
-     * @return static
-     */
-    public function placeholder($placeholder)
-    {
-        return $this->attribute('placeholder', $placeholder);
-    }
-
-    /**
-     * @param bool $required
-     *
-     * @return static
-     */
-    public function required($required = true)
-    {
-        return $required
-            ? $this->attribute('required')
-            : $this->forgetAttribute('required');
-    }
-
-    /**
-     * @param string|null $type
-     *
-     * @return static
-     */
-    public function type($type)
-    {
-        return $this->attribute('type', $type);
-    }
-
-    /**
-     * @return static
-     */
-    public function unchecked()
-    {
-        return $this->checked(false);
-    }
-
-    /**
-     * @param string|null $value
-     *
-     * @return static
-     */
-    public function value($value)
-    {
-        return $this->attribute('value', $value);
-    }
-
-    /**
-     * @param bool $readonly
-     *
-     * @return static
-     */
-    public function readonly($readonly = true)
-    {
-        return $readonly
-            ? $this->attribute('readonly')
-            : $this->forgetAttribute('readonly');
     }
 
     /**

--- a/src/Elements/Option.php
+++ b/src/Elements/Option.php
@@ -3,10 +3,13 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Value;
 use Spatie\Html\Selectable;
 
 class Option extends BaseElement implements Selectable
 {
+    use Value;
+
     /** @var string */
     protected $tag = 'option';
 
@@ -36,15 +39,5 @@ class Option extends BaseElement implements Selectable
     public function unselected()
     {
         return $this->forgetAttribute('selected');
-    }
-
-    /**
-     * @param string|null $value
-     *
-     * @return static
-     */
-    public function value($value)
-    {
-        return $this->attribute('value', $value);
     }
 }

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -8,6 +8,7 @@ use Spatie\Html\BaseElement;
 use Spatie\Html\Elements\Attributes\Autofocus;
 use Spatie\Html\Elements\Attributes\Disabled;
 use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Readonly;
 use Spatie\Html\Elements\Attributes\Required;
 use Spatie\Html\Selectable;
 
@@ -17,6 +18,7 @@ class Select extends BaseElement
     use Disabled;
     use Name;
     use Required;
+    use Readonly;
 
     /** @var string */
     protected $tag = 'select';

--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -5,10 +5,19 @@ namespace Spatie\Html\Elements;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Autofocus;
+use Spatie\Html\Elements\Attributes\Disabled;
+use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Required;
 use Spatie\Html\Selectable;
 
 class Select extends BaseElement
 {
+    use Autofocus;
+    use Disabled;
+    use Name;
+    use Required;
+
     /** @var string */
     protected $tag = 'select';
 
@@ -36,16 +45,6 @@ class Select extends BaseElement
         $element->applyValueToOptions();
 
         return $element;
-    }
-
-    /**
-     * @param string|null $name
-     *
-     * @return static
-     */
-    public function name($name)
-    {
-        return $this->attribute('name', $name);
     }
 
     /**
@@ -100,14 +99,6 @@ class Select extends BaseElement
                 ->text($text)
                 ->selectedIf(! $this->hasSelection())
         );
-    }
-
-    /**
-     * @return static
-     */
-    public function required()
-    {
-        return $this->attribute('required');
     }
 
     /**

--- a/src/Elements/Textarea.php
+++ b/src/Elements/Textarea.php
@@ -3,54 +3,54 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Autofocus;
+use Spatie\Html\Elements\Attributes\Disabled;
+use Spatie\Html\Elements\Attributes\MinMaxLength;
+use Spatie\Html\Elements\Attributes\Name;
+use Spatie\Html\Elements\Attributes\Placeholder;
+use Spatie\Html\Elements\Attributes\Readonly;
+use Spatie\Html\Elements\Attributes\Required;
 
 class Textarea extends BaseElement
 {
+    use Autofocus;
+    use Placeholder;
+    use Name;
+    use Required;
+    use Disabled;
+    use Readonly;
+    use MinMaxLength;
+
     protected $tag = 'textarea';
-
-    /**
-     * @return static
-     */
-    public function autofocus()
-    {
-        return $this->attribute('autofocus');
-    }
-
-    /**
-     * @param string|null $placeholder
-     *
-     * @return static
-     */
-    public function placeholder($placeholder)
-    {
-        return $this->attribute('placeholder', $placeholder);
-    }
-
-    /**
-     * @param string $name
-     *
-     * @return static
-     */
-    public function name($name)
-    {
-        return $this->attribute('name', $name);
-    }
-
-    /**
-     * @return static
-     */
-    public function required()
-    {
-        return $this->attribute('required');
-    }
 
     /**
      * @param string|null $value
      *
      * @return static
+     * @throws \Spatie\Html\Exceptions\InvalidHtml
      */
     public function value($value)
     {
         return $this->html($value);
+    }
+
+    /**
+     * @param int $rows
+     *
+     * @return static
+     */
+    public function rows(int $rows)
+    {
+        return $this->attribute('rows', $rows);
+    }
+
+    /**
+     * @param int $cols
+     *
+     * @return static
+     */
+    public function cols(int $cols)
+    {
+        return $this->attribute('cols', $cols);
     }
 }

--- a/tests/Elements/FileTest.php
+++ b/tests/Elements/FileTest.php
@@ -26,6 +26,24 @@ class FileTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_file_that_has_autofocus_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="file" autofocus>',
+            File::create()->autofocus(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_file_that_has_autofocus_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="file">',
+            File::create()->autofocus(false)
+        );
+    }
+
+    /** @test */
     public function it_can_create_an_required_file()
     {
         $this->assertHtmlStringEqualsHtmlString(

--- a/tests/Elements/FormTest.php
+++ b/tests/Elements/FormTest.php
@@ -44,11 +44,29 @@ class FormTest extends TestCase
     }
 
     /** @test */
-    public function it_can_create_a_form_that_add_novalidate_attribute()
+    public function it_can_create_a_form_with_a_novalidate_attribute()
     {
         $this->assertHtmlStringEqualsHtmlString(
             '<form enctype="multipart/form-data" novalidate=""></form>',
             Form::create()->novalidate()->acceptsFiles()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_form_that_has_novalidate_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<form enctype="multipart/form-data" novalidate=""></form>',
+            Form::create()->novalidate(true)->acceptsFiles()
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_form_that_has_novalidate_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<form enctype="multipart/form-data"></form>',
+            Form::create()->novalidate(false)->acceptsFiles()
         );
     }
 }

--- a/tests/Elements/InputTest.php
+++ b/tests/Elements/InputTest.php
@@ -89,6 +89,24 @@ class InputTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_an_input_that_has_autofocus_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input autofocus>',
+            Input::create()->autofocus(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_an_input_that_has_autofocus_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input>',
+            Input::create()->autofocus(false)
+        );
+    }
+
+    /** @test */
     public function it_can_check_an_input()
     {
         $this->assertHtmlStringEqualsHtmlString(
@@ -122,6 +140,24 @@ class InputTest extends TestCase
         $this->assertHtmlStringEqualsHtmlString(
             '<input type="checkbox" disabled>',
             Input::create()->type('checkbox')->disabled()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_an_input_with_maxlength()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="text" maxlength="25">',
+            Input::create()->type('text')->maxlength(25)
+        );
+    }
+
+    /** @test */
+    public function it_can_create_an_input_with_minlength()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<input type="text" minlength="25">',
+            Input::create()->type('text')->minlength(25)
         );
     }
 }

--- a/tests/Elements/SelectTest.php
+++ b/tests/Elements/SelectTest.php
@@ -178,4 +178,103 @@ class SelectTest extends TestCase
                 ->render()
         );
     }
+
+    /** @test */
+    public function it_can_create_a_disabled_select()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select disabled>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->disabled()->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_is_disabled_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select disabled>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->disabled(true)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_select_that_is_disabled_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->disabled(false)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_has_autofocus()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select autofocus>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->autofocus()->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_has_autofocus_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select autofocus>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->autofocus(true)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_select_that_has_autofocus_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->autofocus(false)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_is_required()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select required>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->required()->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_is_required_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select required>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->required(true)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_select_that_is_required_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->required(false)->options(['value1' => 'text1'])->render()
+        );
+    }
 }

--- a/tests/Elements/SelectTest.php
+++ b/tests/Elements/SelectTest.php
@@ -277,4 +277,37 @@ class SelectTest extends TestCase
             Select::create()->required(false)->options(['value1' => 'text1'])->render()
         );
     }
+
+    /** @test */
+    public function it_can_create_a_select_that_is_readonly()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select readonly>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->readonly()->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_select_that_is_readonly_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select readonly>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->readonly(true)->options(['value1' => 'text1'])->render()
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_select_that_is_readonly_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<select>
+                <option value="value1">text1</option>
+            </select>',
+            Select::create()->readonly(false)->options(['value1' => 'text1'])->render()
+        );
+    }
 }

--- a/tests/Elements/TextareaTest.php
+++ b/tests/Elements/TextareaTest.php
@@ -60,4 +60,94 @@ class TextareaTest extends TestCase
             Textarea::create()->value('My epic')
         );
     }
+
+    /** @test */
+    public function it_can_create_a_textarea_that_is_required_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea required>My epic</textarea>',
+            Textarea::create()->value('My epic')->required(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_textarea_that_is_required_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea>My epic</textarea>',
+            Textarea::create()->value('My epic')->required(false)
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_disabled_textarea()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea disabled>My epic</textarea>',
+            Textarea::create()->value('My epic')->disabled()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_textarea_that_is_disabled_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea disabled>My epic</textarea>',
+            Textarea::create()->value('My epic')->disabled(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_textarea_that_is_disabled_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea>My epic</textarea>',
+            Textarea::create()->value('My epic')->disabled(false)
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_readonly_textarea()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea readonly>My epic</textarea>',
+            Textarea::create()->value('My epic')->readonly()
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_textarea_that_is_readonly_when_passing_true()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea readonly>My epic</textarea>',
+            Textarea::create()->value('My epic')->readonly(true)
+        );
+    }
+
+    /** @test */
+    public function it_wont_create_a_textarea_that_is_readonly_when_passing_false()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea>My epic</textarea>',
+            Textarea::create()->value('My epic')->readonly(false)
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_textarea_with_maxlength()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea maxlength="25">My epic</textarea>',
+            Textarea::create()->value('My epic')->maxlength(25)
+        );
+    }
+
+    /** @test */
+    public function it_can_create_a_textarea_with_minlength()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<textarea minlength="25">My epic</textarea>',
+            Textarea::create()->value('My epic')->minlength(25)
+        );
+    }
 }


### PR DESCRIPTION
In summary:

This is a fairly large refactor. My goal was to normalise the attribute methods available across elements. As it stands, they vary quite a bit. Some signatures are different, some are present on some elements but not others. I also added some that I use a lot. 27 new tests have been added to account for them all. It's fully backwards compatible with the existing code.

Draft as there are some possible changes that could be made. Namely if the new traits could live in a different namespace or have a different naming scheme. 

In detail:

The following common attributes have been moved into traits:

* Autofocus
* Disabled
* Name
* Placeholder
* Readonly
* Required
* Type
* Value

Attributes that are boolean in nature now universally accept a parameter to toggle them on or off. Previously some elements and attributes had this but some did not. For example `Select::required()` vs `Input::required($required = true)`. Affected elements and attributes are:

* `Form::novalidate($novalidate = true)`
* `Select::required($required = true)`
* `File::required($required = true)`
* `File::autofocus($autofocus = true)`

Attributes moved into traits have been added to elements where they were previously missing if the element supports them. These are:

* `File::autofocus(?$autofocus)`
* `Input::autofocus(?$autofocus)`
* `Select::autofocus(?$autofocus)`
* `Select::disabled(?$disabled)`
* `Select::required(?$required)`
* `Textarea::disabled(?$disabled)`
* `Textarea::readonly(?$readonly)`
* `Textarea::required(?$required)`

The following useful attributes have been added:

* `Input::maxlength(int $maxlength)`
* `Input::minlength(int $minlength)`
* `Textarea::maxlength(int $maxlength)`
* `Textarea::minlength(int $minlength)`
* `Textarea::cols(int $cols)`
* `Textarea::rows(int $rows)`

`minlength` and `maxlength` live in a new trait as they are shared across two different elements.