### PR TITLE
Add p element

### DIFF
--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -99,6 +99,8 @@ echo Element::withTag('p')->text('This is the content!');
 - `function unselected()`
 - `function value(?string $value)`
 
+## `P`
+
 ## `Select`
 
 - `function autofocus(?$autofocus)`

--- a/src/Elements/P.php
+++ b/src/Elements/P.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Html\Elements;
+
+use Spatie\Html\BaseElement;
+
+class P extends BaseElement
+{
+    protected $tag = 'p';
+}

--- a/src/Html.php
+++ b/src/Html.php
@@ -22,6 +22,7 @@ use Spatie\Html\Elements\Input;
 use Spatie\Html\Elements\Label;
 use Spatie\Html\Elements\Legend;
 use Spatie\Html\Elements\Option;
+use Spatie\Html\Elements\P;
 use Spatie\Html\Elements\Select;
 use Spatie\Html\Elements\Span;
 use Spatie\Html\Elements\Textarea;
@@ -66,6 +67,17 @@ class Html
     public function i($contents = null)
     {
         return I::create()
+            ->html($contents);
+    }
+
+    /**
+     * @param \Spatie\Html\HtmlElement|string|null $contents
+     *
+     * @return \Spatie\Html\Elements\P
+     */
+    public function p($contents = null)
+    {
+        return P::create()
             ->html($contents);
     }
 

--- a/tests/Elements/PTest.php
+++ b/tests/Elements/PTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Html\Test\Elements;
+
+use Spatie\Html\Elements\P;
+use Spatie\Html\Test\TestCase;
+
+class PTest extends TestCase
+{
+    /** @test */
+    public function it_can_create_an_p_element()
+    {
+        $this->assertHtmlStringEqualsHtmlString(
+            '<p></p>',
+            P::create()
+        );
+    }
+}


### PR DESCRIPTION
This PR is adding <p> as an element. It's a very usual tag, so I thought that it would be nice if we can have it as an element.

I saw in the documentation a few examples with it, but couldn't find that class. Seems to me that it's possible only to create it through "withTag" method.

Sorry if I misunderstood something.

Let me know if you have any suggestions.

Thanks!