### PR TITLE
Allow setting a form action to a route

### DIFF
--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -22,6 +22,17 @@ class Form extends BaseElement
     }
 
     /**
+     * @param string|null $route
+     * @param mixed $params
+     *
+     * @return static
+     */
+    public function route($route, ...$params)
+    {
+        return $this->action(route($route, ...$params));
+    }
+
+    /**
      * @param string|null $method
      *
      * @return static


### PR DESCRIPTION
This PR simply adds a `Form::route()` method to simplify what is no doubt a very commonly repeated bit of code.
```php
// before
html()->form()->action(route('my_route_name', ['param1', 44]))->open();
//after
html()->form()->route('my_route_name', ['param1', 44])->open();
```

I didn't add any tests as it's just using the `Form::action()` method internally.