### PR TITLE
Correction to docs re: readonly vs isReadonly

### DIFF
--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -3,7 +3,7 @@ title: Element classes
 weight: 3
 ---
 
-This package includes some element classes out of the box, others can be created using the [generic `Spatie\Html\Elements\Element` class](#generic-codeelementcode). 
+This package includes some element classes out of the box, others can be created using the [generic `Spatie\Html\Elements\Element` class](#generic-codeelementcode).
 
 All elements can use the [base element methods](/laravel-html/v1/general-usage/element-methods). Some elements also have some element specific methods to easily set common attributes. These element specific methods can be found bellow.
 
@@ -69,9 +69,9 @@ echo Element::withTag('p')->text('This is the content!');
 - `function autofocus(?$autofocus)`
 - `function checked($checked = true)`
 - `function disabled($disabled = true)`
+- `function isReadonly($readonly = true)`
 - `function name(?string $name)`
 - `function placeholder(?string $placeholder)`
-- `function readonly($readonly = true)`
 - `function required($required = true)`
 - `function size($size)`
 - `function type(?string $type)`
@@ -105,12 +105,12 @@ echo Element::withTag('p')->text('This is the content!');
 
 - `function autofocus(?$autofocus)`
 - `function disabled(?$disabled)`
+- `function isReadonly(?$readonly)`
 - `function multiple()`
 - `function name(?string $name)`
 - `function optgroup(string $label, iterable $options)`
 - `function options(iterable $options)`
 - `function placeholder(?$text)`
-- `function readonly(?$readonly)`
 - `function required(?$required)`
 - `function value(?string $value)`
 
@@ -121,11 +121,11 @@ echo Element::withTag('p')->text('This is the content!');
 - `function autofocus()`
 - `function cols(int $cols)`
 - `function disabled(?$disabled)`
+- `function isReadonly(?$readonly)`
 - `function maxlength(int $maxlength)`
 - `function minlength(int $minlength)`
 - `function name(?string $name)`
 - `function placeholder(?string $placeholder)`
-- `function readonly(?$readonly)`
 - `function required()`
 - `function required(?$required)`
 - `function rows(int $rows)`

--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -50,9 +50,9 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Form`
 
+- `function acceptsFiles()`
 - `function action(?string $action)`
 - `function method(?string $method)`
-- `function acceptsFiles()`
 - `function novalidate($novalidate = true)`
 - `function target(string $target)`
 
@@ -70,6 +70,8 @@ echo Element::withTag('p')->text('This is the content!');
 - `function checked($checked = true)`
 - `function disabled($disabled = true)`
 - `function isReadonly($readonly = true)`
+- `function maxlength(int $maxlength)`
+- `function minlength(int $minlength)`
 - `function name(?string $name)`
 - `function placeholder(?string $placeholder)`
 - `function required($required = true)`
@@ -77,8 +79,6 @@ echo Element::withTag('p')->text('This is the content!');
 - `function type(?string $type)`
 - `function unchecked()`
 - `function value(?string $value)`
-- `function maxlength(int $maxlength)`
-- `function minlength(int $minlength)`
 
 ## `Label`
 


### PR DESCRIPTION
I was in the process of switching a project from laravelcollective/html to this one, and happened to notice that the readonly() method wasn't working as documented. Digging in, I see the history, that it was renamed in version 3.0.0. This PR simply updates the documentation to reflect that change. In the process of updating the relevant file, I noticed a couple other methods out of order (where they are otherwise alphabetical) so I took the liberty of sneaking in a second commit to reorder those.