### PR TITLE
Get value from model with casts php native enum

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Html;
 
+use BackedEnum;
 use DateTimeImmutable;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Http\Request;
@@ -26,6 +27,7 @@ use Spatie\Html\Elements\P;
 use Spatie\Html\Elements\Select;
 use Spatie\Html\Elements\Span;
 use Spatie\Html\Elements\Textarea;
+use UnitEnum;
 
 class Html
 {
@@ -591,7 +593,9 @@ class Html
         // has a model assigned and there aren't old input items,
         // try to retrieve a value from the model.
         if (is_null($value) && $this->model && empty($this->request->old())) {
-            $value = data_get($this->model, $name) ?? '';
+            $value = ($value = data_get($this->model, $name)) instanceof UnitEnum
+                ? $this->getEnumValue($value)
+                : $value;
         }
 
         return $this->request->old($name, $value);
@@ -646,5 +650,18 @@ class Html
         } catch (\Exception $e) {
             return $value;
         }
+    }
+
+    /**
+     * Get the value from the given enum.
+     *
+     * @param  \UnitEnum|\BackedEnum  $value
+     * @return string|int
+     */
+    protected function getEnumValue($value)
+    {
+        return $value instanceof BackedEnum
+                ? $value->value
+                : $value->name;
     }
 }

--- a/tests/Html/ModelFormTest.php
+++ b/tests/Html/ModelFormTest.php
@@ -1,10 +1,31 @@
 <?php
 
+use Spatie\Html\Test\Stubs\Role;
+use Spatie\Html\Test\Stubs\Status;
+
 it('can create a form from a model', function () {
     assertHtmlStringEqualsHtmlString(
         '<form method="POST">' .
             '<input name="_token" type="hidden" value="abc">' .
             '</form>',
         $this->html->modelForm([])
+    );
+});
+
+it('returns an enum value from a name with an enum cast in the model', function () {
+    withModel(['relation' => ['role' => Role::Admin]]);
+    assertHtmlStringEqualsHtmlString(
+        '<input type="text" name="relation[role]" id="relation[role]" value="Admin">',
+        $this->html->text('relation[role]')
+    );
+
+    withModel(['select' => Status::Pending]);
+    assertHtmlStringEqualsHtmlString(
+        '<select name="select" id="select">
+            <option value="0">Unknown</option>
+            <option value="1" selected="selected">Pending</option>
+            <option value="2">Complete</option>
+        </select>',
+        $this->html->select('select', Status::asSelectArray())->render()
     );
 });

--- a/tests/Stubs/Role.php
+++ b/tests/Stubs/Role.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\Html\Test\Stubs;
+
+enum Role
+{
+    case User;
+    case Manager;
+    case Admin;
+}

--- a/tests/Stubs/Status.php
+++ b/tests/Stubs/Status.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\Html\Test\Stubs;
+
+enum Status: int
+{
+    case Unknown = 0;
+    case Pending = 1;
+    case Complete = 2;
+
+    /**
+     * Get the enum as an array formatted for a select.
+     *
+     * @return array
+     */
+    public static function asSelectArray()
+    {
+        return array_column(self::cases(), 'name', 'value');
+    }
+}


### PR DESCRIPTION
With this PR when casts the model attribute with php native enum, laravel-html gets the enum's value or name for inputs.