### PR TITLE
Fix docblock to solve phpstan errors when passing an array to html()->div()

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -131,7 +131,7 @@ class Html
     }
 
     /**
-     * @param \Spatie\Html\HtmlElement|string|null $contents
+     * @param \Spatie\Html\HtmlElement|string|iterable|int|float|null $contents
      *
      * @return \Spatie\Html\Elements\Div
      */


### PR DESCRIPTION
Fixes the following phpstan error:
```
Parameter #1 $contents of method Spatie\Html\Html::div() expects               
         Spatie\Html\HtmlElement|string|null, array<int, Spatie\Html\Elements\Element>  
         given.      
```

for the given code:

```
html()->div([
    html()->p('example'),
    html()->p('second child'),
]);
```

This PR updates the docblock of `div` (`html()->div()`) to match the types of `BaseElement::children()` since it just forwards to that function.

