### PR TITLE
Add Search & support Collections in Select

### DIFF
--- a/src/Elements/Select.php
+++ b/src/Elements/Select.php
@@ -57,7 +57,7 @@ class Select extends BaseElement
     public function options($options)
     {
         return $this->addChildren($options, function ($text, $value) {
-            if (is_array($text)) {
+            if (is_array($text) || $text instanceof Collection) {
                 return $this->optgroup($value, $text);
             }
 
@@ -84,8 +84,6 @@ class Select extends BaseElement
                     ->text($text)
                     ->selectedIf($value === $this->value);
             });
-
-        return $this->addChild($optgroup);
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -154,6 +154,17 @@ class Html
     /**
      * @param string|null $name
      * @param string|null $value
+     *
+     * @return \Spatie\Html\Elements\Input
+     */
+    public function search($name = null, $value = null)
+    {
+        return $this->input('search', $name, $value);
+    }
+
+    /**
+     * @param string|null $name
+     * @param string|null $value
      * @param bool $format
      *
      * @return \Spatie\Html\Elements\Input

--- a/tests/Html/InputTest.php
+++ b/tests/Html/InputTest.php
@@ -267,3 +267,17 @@ it('can create a number input with max step', function () {
         $this->html->number('test', '30', null, '100', '10')
     );
 });
+
+it('can create a search input', function () {
+    assertHtmlStringEqualsHtmlString(
+        '<input type="search">',
+        $this->html->search()
+    );
+});
+
+it('can create a search input with blank date', function () {
+    assertHtmlStringEqualsHtmlString(
+        '<input id="test_search" name="test_search" type="search" value=""/>',
+        $this->html->search('test_search', '')
+    );
+});

--- a/tests/Html/SelectTest.php
+++ b/tests/Html/SelectTest.php
@@ -60,3 +60,75 @@ it('can render a select element with options with a selected value when the valu
         $this->html->select('select', $options, '+2')->render()
     );
 });
+
+it('can render a select element with options in groups', function () {
+    $options = [
+        'group' => [
+            'value1' => 'text1',
+            'value2' => 'text2',
+        ],
+    ];
+
+    assertHtmlStringEqualsHtmlString(
+        '<select name="select" id="select">
+                <optgroup label="group">
+                    <option value="value1">text1</option>
+                    <option value="value2">text2</option>
+                </optgroup>
+            </select>',
+        $this->html->select('select', $options)->render()
+    );
+});
+
+it('can render a select element with collection of options with a selected value', function () {
+    $options = collect([
+        'value1' => 'text1',
+        'value2' => 'text2',
+    ]);
+
+    assertHtmlStringEqualsHtmlString(
+        '<select name="select" id="select">
+                <option value="value1" selected="selected">text1</option>
+                <option value="value2">text2</option>
+            </select>',
+        $this->html->select('select', $options, 'value1')->render()
+    );
+});
+
+it('can render a select element with a collection of options in groups', function () {
+    $options = [
+        'group' => collect([
+            'value1' => 'text1',
+            'value2' => 'text2',
+        ]),
+    ];
+
+    assertHtmlStringEqualsHtmlString(
+        '<select name="select" id="select">
+                <optgroup label="group">
+                    <option value="value1">text1</option>
+                    <option value="value2">text2</option>
+                </optgroup>
+            </select>',
+        $this->html->select('select', $options)->render()
+    );
+});
+
+it('can render a select element of a collection with options in groups', function () {
+    $options = collect([
+        'group' => collect([
+            'value1' => 'text1',
+            'value2' => 'text2',
+        ]),
+    ]);
+
+    assertHtmlStringEqualsHtmlString(
+        '<select name="select" id="select">
+                <optgroup label="group">
+                    <option value="value1">text1</option>
+                    <option value="value2">text2</option>
+                </optgroup>
+            </select>',
+        $this->html->select('select', $options)->render()
+    );
+});


### PR DESCRIPTION
I'm trying to switch to this package from the Laravel Collective HTML package. But i'm missing the search input type option which is supported in the Laravel Collective package and ofcourse is also a valid html input type. 

Also i'm using collections in the select component which is not supported in this package. This PR adds that support. 

Would love if this could be merged, but understand if it's not to your liking. 
Let me know if you want any changes or if this is not something you want to support. 