### PR TITLE
Added support for Htmlable contents in BaseElement

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -52,7 +52,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         $element = clone $this;
 
-        $element->attributes->setAttribute($attribute, (string)$value);
+        $element->attributes->setAttribute($attribute, (string) $value);
 
         return $element;
     }
@@ -325,7 +325,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function unless(bool $condition, \Closure $callback)
     {
-        return $this->if(!$condition, $callback);
+        return $this->if(! $condition, $callback);
     }
 
     /**
@@ -339,7 +339,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function ifNotNull($value, \Closure $callback)
     {
-        return !is_null($value) ? $callback($this) : $this;
+        return ! is_null($value) ? $callback($this) : $this;
     }
 
     /**
@@ -405,8 +405,8 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * Dynamically handle calls to the class.
      * Check for methods finishing by If or fallback to Macroable.
      *
-     * @param string $name
-     * @param array $arguments
+     * @param  string $name
+     * @param  array $arguments
      * @return mixed
      *
      * @throws BadMethodCallException
@@ -415,7 +415,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         if (Str::endsWith($name, $conditions = ['If', 'Unless', 'IfNotNull'])) {
             foreach ($conditions as $condition) {
-                if (!method_exists($this, $method = str_replace($condition, '', $name))) {
+                if (! method_exists($this, $method = str_replace($condition, '', $name))) {
                     continue;
                 }
 
@@ -435,9 +435,9 @@ abstract class BaseElement implements Htmlable, HtmlElement
 
         switch ($type) {
             case 'If':
-                return $this->if((bool)$value, $callback);
+                return $this->if((bool) $value, $callback);
             case 'Unless':
-                return $this->unless((bool)$value, $callback);
+                return $this->unless((bool) $value, $callback);
             case 'IfNotNull':
                 return $this->ifNotNull($value, $callback);
             default:

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -405,8 +405,8 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * Dynamically handle calls to the class.
      * Check for methods finishing by If or fallback to Macroable.
      *
-     * @param  string $name
-     * @param  array $arguments
+     * @param  string  $name
+     * @param  array   $arguments
      * @return mixed
      *
      * @throws BadMethodCallException

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -52,7 +52,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         $element = clone $this;
 
-        $element->attributes->setAttribute($attribute, (string) $value);
+        $element->attributes->setAttribute($attribute, (string)$value);
 
         return $element;
     }
@@ -325,7 +325,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function unless(bool $condition, \Closure $callback)
     {
-        return $this->if(! $condition, $callback);
+        return $this->if(!$condition, $callback);
     }
 
     /**
@@ -339,7 +339,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function ifNotNull($value, \Closure $callback)
     {
-        return ! is_null($value) ? $callback($this) : $this;
+        return !is_null($value) ? $callback($this) : $this;
     }
 
     /**
@@ -405,8 +405,8 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * Dynamically handle calls to the class.
      * Check for methods finishing by If or fallback to Macroable.
      *
-     * @param  string  $name
-     * @param  array   $arguments
+     * @param string $name
+     * @param array $arguments
      * @return mixed
      *
      * @throws BadMethodCallException
@@ -415,7 +415,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         if (Str::endsWith($name, $conditions = ['If', 'Unless', 'IfNotNull'])) {
             foreach ($conditions as $condition) {
-                if (! method_exists($this, $method = str_replace($condition, '', $name))) {
+                if (!method_exists($this, $method = str_replace($condition, '', $name))) {
                     continue;
                 }
 
@@ -435,9 +435,9 @@ abstract class BaseElement implements Htmlable, HtmlElement
 
         switch ($type) {
             case 'If':
-                return $this->if((bool) $value, $callback);
+                return $this->if((bool)$value, $callback);
             case 'Unless':
-                return $this->unless((bool) $value, $callback);
+                return $this->unless((bool)$value, $callback);
             case 'IfNotNull':
                 return $this->ifNotNull($value, $callback);
             default:
@@ -465,6 +465,8 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         if ($children instanceof HtmlElement) {
             $children = [$children];
+        } elseif ($children instanceof Htmlable) {
+            $children = $children->toHtml();
         }
 
         $children = Collection::make($children);

--- a/tests/Html/ButtonTest.php
+++ b/tests/Html/ButtonTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Contracts\Support\Htmlable;
+
 it('can create a button', function () {
     assertHtmlStringEqualsHtmlString(
         '<button></button>',
@@ -18,6 +20,13 @@ it('can create a button with html contents', function () {
     assertHtmlStringEqualsHtmlString(
         '<button><em>Hi</em></button>',
         $this->html->button('<em>Hi</em>')
+    );
+});
+
+it('can create a button with Htmlable contents', function () {
+    assertHtmlStringEqualsHtmlString(
+        '<button>Hi</button>',
+        $this->html->button(new \Illuminate\View\ComponentSlot('Hi'))
     );
 });
 

--- a/tests/Html/ButtonTest.php
+++ b/tests/Html/ButtonTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Contracts\Support\Htmlable;
-
 it('can create a button', function () {
     assertHtmlStringEqualsHtmlString(
         '<button></button>',


### PR DESCRIPTION
I've recently update to laravel/framework 10.19.0 and noticed that it breaks on of my components. 
Error message is: The given child should implement `Spatie\Html\HtmlElement` or be a string

My component looks like this: 
```
<!-- Send button -->
<div class="row form-group text-center">
    <div class="col-lg-12">
        {{
            html()
                ->submit($slot)
                ->class(['btn', 'btn-primary'] + (($disabled ?? false) ? ['disabled'] : []))
                ->class($class ?? [])
                ->id($id ?? 'submit')
                ->attribute(isset($form) ? 'form' : '', $form ?? '')
                ->disabled(($disabled ?? false) ? "disabled": "")
        }}
    </div>
</div>
```
And i use it like this:
```
@component('fc::submit')
       {{ __('save') }}
@endcomponent
```
This is my fix for the problem. also reported here: https://github.com/spatie/laravel-html/discussions/193
