### PR TITLE
Fix link with version in documentation

### DIFF
--- a/docs/general-usage/core-concepts.md
+++ b/docs/general-usage/core-concepts.md
@@ -5,17 +5,17 @@ weight: 1
 
 ## `Element` classes
 
-This package contains several element classes under the `Spatie\Html\Elements` namespace. It's possible to generate any HTML element with any attribute via these classes and the [fluent element methods](/laravel-html/v1/general-usage/element-methods).
+This package contains several element classes under the `Spatie\Html\Elements` namespace. It's possible to generate any HTML element with any attribute via these classes and the [fluent element methods](/laravel-html/general-usage/element-methods).
 
 `Element` classes on their own don't have any knowledge of the outside world. That's where the `Spatie\Html\Html` builder comes into play.
 
 ## `Html` Builder class
 
-The `Spatie\Html\Html` builder is used to build proper HTML using its [builder methods](/laravel-html/v1/general-usage/html-builder). It will also couple `Spatie\Html\Elements` to other concepts like requests, sessions and models.
+The `Spatie\Html\Html` builder is used to build proper HTML using its [builder methods](/laravel-html/general-usage/html-builder). It will also couple `Spatie\Html\Elements` to other concepts like requests, sessions and models.
 
 For example when building input fields the `Html` builder will pull old values from the session (on a failed form request) or use values of a given model for the `value` attribute of the input.
 
-Because the `Html` builder will generally return `Spatie\Html\Elements`, you can chain most of the [elements' fluent methods](/laravel-html/v1/general-usage/element-methods) directly onto the builder.
+Because the `Html` builder will generally return `Spatie\Html\Elements`, you can chain most of the [elements' fluent methods](/laravel-html/general-usage/element-methods) directly onto the builder.
 
 ## The Difference Between Builder Params and Element Methods
 

--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -5,7 +5,7 @@ weight: 3
 
 This package includes some element classes out of the box, others can be created using the [generic `Spatie\Html\Elements\Element` class](#generic-codeelementcode).
 
-All elements can use the [base element methods](/laravel-html/v1/general-usage/element-methods). Some elements also have some element specific methods to easily set common attributes. These element specific methods can be found bellow.
+All elements can use the [base element methods](/laravel-html/general-usage/element-methods). Some elements also have some element specific methods to easily set common attributes. These element specific methods can be found bellow.
 
 ## Generic `Element`
 

--- a/docs/general-usage/extending.md
+++ b/docs/general-usage/extending.md
@@ -7,7 +7,6 @@ If you want to extend the Html package, you can do the following.
 
 Create a class that extends Html:
 
-
 ```php
 <?php
 

--- a/docs/general-usage/html-builder.md
+++ b/docs/general-usage/html-builder.md
@@ -5,7 +5,7 @@ weight: 2
 
 ## Building general elements
 
-The following builder methods can be used to generate general HTML elements like links, `div`s, `span`s, etc... All these methods return instances of `Spatie\Html\Elements`. Of course all [element methods](/laravel-html/v1/general-usage/element-methods) are available on the returned instances.
+The following builder methods can be used to generate general HTML elements like links, `div`s, `span`s, etc... All these methods return instances of `Spatie\Html\Elements`. Of course all [element methods](/laravel-html/general-usage/element-methods) are available on the returned instances.
 
 - `function a($href = null, $text = null): A`
 - `function button($text = null, $type = 'button'): Button`

--- a/docs/general-usage/the-class-helper.md
+++ b/docs/general-usage/the-class-helper.md
@@ -3,7 +3,7 @@ title: The class() helper
 weight: 5
 ---
 
-The `class` method on `Html` is a helper to render a `class` attribute similar to [Vue.js' `:class` property](https://vuejs.org/guide/class-and-style.html#Object-Syntax).
+The `class` method on `Html` is a helper to render a `class` attribute similar to [Vue.js' `:class` property](https://vuejs.org/guide/essentials/class-and-style.html#Object-Syntax).
 
 It expects an array (or a `Collection`), and will toggle a set of classes depending on the values of the array.
 

--- a/docs/general-usage/the-class-helper.md
+++ b/docs/general-usage/the-class-helper.md
@@ -3,7 +3,7 @@ title: The class() helper
 weight: 5
 ---
 
-The `class` method on `Html` is a helper to render a `class` attribute similar to [Vue.js' `:class` property](https://vuejs.org/v2/guide/class-and-style.html#Object-Syntax).
+The `class` method on `Html` is a helper to render a `class` attribute similar to [Vue.js' `:class` property](https://vuejs.org/guide/class-and-style.html#Object-Syntax).
 
 It expects an array (or a `Collection`), and will toggle a set of classes depending on the values of the array.
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -7,7 +7,7 @@ This package helps you generate HTML using a clean, simple and easy to read API.
 
 ### Generating elements
 
-For example creating a new `span` element with a class is super easy with the [fluent methods for elements](/laravel-html/v1/general-usage/element-methods):
+For example creating a new `span` element with a class is super easy with the [fluent methods for elements](/laravel-html/general-usage/element-methods):
 
  ```php
 html()->span()->text('Hello world!')->class('fa fa-eye');


### PR DESCRIPTION
Some links was to old doc version.

I removed version from url. 
Without version user will be redirected anyway to current version
```
https://spatie.be/docs/laravel-html/general-usage/element-methods  -> 
https://spatie.be/docs/laravel-html/v3/general-usage/element-methods
```