### PR TITLE
Add autocomplete attribute helper to the form element

### DIFF
--- a/docs/general-usage/element-classes.md
+++ b/docs/general-usage/element-classes.md
@@ -52,6 +52,7 @@ echo Element::withTag('p')->text('This is the content!');
 
 - `function acceptsFiles()`
 - `function action(?string $action)`
+- `function autocomplete(bool|string $autocomplete = true)`
 - `function method(?string $method)`
 - `function novalidate($novalidate = true)`
 - `function target(string $target)`
@@ -66,7 +67,7 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Input`
 
-- `function autocomplete(?$autocomplete)`
+- `function autocomplete(bool|string $autocomplete = true)`
 - `function autofocus(?$autofocus)`
 - `function checked($checked = true)`
 - `function disabled($disabled = true)`
@@ -104,7 +105,7 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Select`
 
-- `function autocomplete(?$autocomplete)`
+- `function autocomplete(bool|string $autocomplete = true)`
 - `function autofocus(?$autofocus)`
 - `function disabled(?$disabled)`
 - `function isReadonly(?$readonly)`
@@ -120,7 +121,7 @@ echo Element::withTag('p')->text('This is the content!');
 
 ## `Textarea`
 
-- `function autocomplete(?$autocomplete)`
+- `function autocomplete(bool|string $autocomplete = true)`
 - `function autofocus()`
 - `function cols(int $cols)`
 - `function disabled(?$disabled)`

--- a/src/Elements/Form.php
+++ b/src/Elements/Form.php
@@ -3,10 +3,12 @@
 namespace Spatie\Html\Elements;
 
 use Spatie\Html\BaseElement;
+use Spatie\Html\Elements\Attributes\Autocomplete;
 use Spatie\Html\Elements\Attributes\Target;
 
 class Form extends BaseElement
 {
+    use Autocomplete;
     use Target;
 
     protected $tag = 'form';

--- a/tests/Elements/FormTest.php
+++ b/tests/Elements/FormTest.php
@@ -26,6 +26,12 @@ it('can create a form that accepts files')
         Form::create()->acceptsFiles()
     );
 
+it('can create a form with a non-autocomplete attribute')
+    ->assertHtmlStringEqualsHtmlString(
+        '<form autocomplete="off"></form>',
+        Form::create()->autocomplete(false)
+    );
+
 it('can create a form with a novalidate attribute')
     ->assertHtmlStringEqualsHtmlString(
         '<form enctype="multipart/form-data" novalidate=""></form>',


### PR DESCRIPTION
Accidentally omitted from #219. Now all elements that are documented to support the `autocomplete` attribute, support this helper.