### PR TITLE
Add aria helper method

### DIFF
--- a/docs/general-usage/element-methods.md
+++ b/docs/general-usage/element-methods.md
@@ -14,6 +14,7 @@ All `Spatie\Html\Elements` have some methods that make working with elements eas
 - [`class()`](#class)
 - [`id()`](#id)
 - [`data()`](#data)
+- [`aria()`](#aria)
 - [`child()` and `children()`](#child-and-children)
 - [`prependChild()` and `prependChildren()`](#prependchild-and-prependchildren)
 - [`text()`](#text)
@@ -101,6 +102,14 @@ Add a data- attribute:
 ```php
 echo Div::data('btn', 123);
 // "<div data-btn="123"></div>"
+```
+
+## `aria()`
+
+Add a aria- attribute:
+```php
+echo Div::aria('describedby', 'bar');
+// "<div aria-describedby="bar"></div>"
 ```
 
 ## `child()` and `children()`

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -170,6 +170,17 @@ abstract class BaseElement implements Htmlable, HtmlElement
     }
 
     /**
+     * @param string $attribute
+     * @param string|null $value
+     *
+     * @return static
+     */
+    public function aria($attribute, $value = null)
+    {
+        return $this->attribute("aria-{$attribute}", $value);
+    }
+
+    /**
      * @param \Spatie\Html\HtmlElement|string|iterable|int|float|null $children
      * @param callable|null $mapper
      *

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -303,3 +303,9 @@ it('can set a data attribute')
         '<div data-foo="bar"></div>',
         Div::create()->data('foo', 'bar')->render()
     );
+
+it('can set a aria attribute')
+    ->assertHtmlStringEqualsHtmlString(
+        '<div aria-describedby="bar"></div>',
+        Div::create()->aria('describedby', 'bar')->render()
+    );


### PR DESCRIPTION
This PR adds `->aria()` helper method to `BaseElement` for global attributes of multiple aria-* states and properties.

```php
{{ html()->email('email')->aria('describedby', 'emailHelp') }}
```

```html
<input  aria-describedby="emailHelp">

<div id="emailHelp">Email help.</div>
```