### PR TITLE
Add Conditionable trait: now `->when()` helper is available on all elements

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 use Spatie\Html\Exceptions\InvalidChild;
 use Spatie\Html\Exceptions\InvalidHtml;
@@ -14,6 +15,8 @@ use Spatie\Html\Exceptions\MissingTag;
 
 abstract class BaseElement implements Htmlable, HtmlElement
 {
+    use Conditionable;
+
     use Macroable {
         __call as __macro_call;
     }

--- a/tests/BaseElementTest.php
+++ b/tests/BaseElementTest.php
@@ -309,3 +309,12 @@ it('can set a aria attribute')
         '<div aria-describedby="bar"></div>',
         Div::create()->aria('describedby', 'bar')->render()
     );
+
+
+it('can make use of the conditionable helper')
+    ->assertHtmlStringEqualsHtmlString(
+        '<div></div>',
+        Div::create()
+            ->when(false, fn(BaseElement $element) => $element->data('foo', 'bar'))
+            ->render()
+    );


### PR DESCRIPTION
I think it's a useful addition for the blade-style chained invocation.

It allows more elegant conditional configuration of attributes, example:

```blade
    {{ html()
        ->select()
        ->when($someCondition, fn(BaseElement $element) => $element->data('foo', 'bar'))))
    }}
```