### PR TITLE
Fix value omitted when input created with no name

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -211,7 +211,7 @@ class Html
      *
      * @return \Spatie\Html\Elements\Input
      */
-    public function range($name = '', $value = '', $min = null, $max = null, $step = null)
+    public function range($name = '', $value = null, $min = null, $max = null, $step = null)
     {
         return $this->input('range', $name, $value)
             ->attributeIfNotNull($min, 'min', $min)
@@ -596,7 +596,7 @@ class Html
     protected function old($name, $value = null)
     {
         if (empty($name)) {
-            return;
+            return $value;
         }
 
         // Convert array format (sth[1]) to dot notation (sth.1)


### PR DESCRIPTION
The change to `old` is quite global, but it makes real world sense, and breaks no tests.

The `range()` default for `$value` was non-standard, all tests run now
![image](https://github.com/spatie/laravel-html/assets/364220/5647d28e-0e1f-459f-9292-e4ffc732d5d8)
