### PR TITLE
fix: Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -297,7 +297,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function text($text)
     {
-        return $this->html(htmlentities($text, ENT_QUOTES, 'UTF-8', false));
+        return $this->html(htmlentities($text ?? '', ENT_QUOTES, 'UTF-8', false));
     }
 
     /**


### PR DESCRIPTION
```bash
[2024-08-09 20:11:06] laravel.WARNING: htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /app/vendor/spatie/laravel-html/src/BaseElement.php on line 300  
[2024-08-09 20:11:06] laravel.EMERGENCY: Unable to create configured logger. Using emergency logger. {"exception":"[object] (InvalidArgumentException(code: 0): Log [deprecations] is not defined. at /app/vendor/laravel/framework/src/Illuminate/Log/LogManager.php:231)
```
My log is filling up with the following message on PHP 8.3.10.

This should fix the warning