### PR TITLE
Radio buttons with value 0 are incorrectly marked as checked

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -433,7 +433,7 @@ class Html
         return $this->input('radio', $name, $value)
             ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug($value)))
             ->attributeIf(! is_null($value), 'value', $value)
-            ->attributeIf((! is_null($value) && $this->old($name) == $value) || $checked, 'checked');
+            ->attributeIf((! is_null($value) && $this->old($name) === $value) || $checked, 'checked');
     }
 
     /**

--- a/tests/Html/RadioTest.php
+++ b/tests/Html/RadioTest.php
@@ -67,8 +67,7 @@ it('can create multiple radio buttons and check the zero value', function () {
     );
 });
 
-it('can create radio button with zero value in first position', function () {
-
+it('can create unchecked radio button with zero value', function () {
     assertHtmlStringEqualsHtmlString(
         '<div>' .
         '<input type="radio" name="my_radio" id="my_radio_0" value="0">' .

--- a/tests/Html/RadioTest.php
+++ b/tests/Html/RadioTest.php
@@ -66,3 +66,17 @@ it('can create multiple radio buttons and check the zero value', function () {
         ])
     );
 });
+
+it('can create radio button with zero value in first position', function () {
+
+    assertHtmlStringEqualsHtmlString(
+        '<div>' .
+        '<input type="radio" name="my_radio" id="my_radio_0" value="0">' .
+        '<input type="radio" name="my_radio" id="my_radio_1" checked="checked" value="1">' .
+        '</div>',
+        $this->html->div([
+            $this->html->radio('my_radio', false, 0),
+            $this->html->radio('my_radio', true, 1),
+        ])
+    );
+});


### PR DESCRIPTION
There is an issue causing radio buttons with value `0` to be marked as checked.

When `$this->old($name)` is `null` and `$value` is `0`, `null == 0` evaluates true.

Using strict comparison fixes the issue.