### PR TITLE
Be able to send form with default values

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -591,7 +591,7 @@ class Html
     }
 
     /**
-     * @param \ArrayAccess|array $model
+     * @param \ArrayAccess|array $defaults
      *
      * @return $this
      */
@@ -603,7 +603,7 @@ class Html
     }
 
     /**
-     * @param \ArrayAccess|array $model
+     * @param \ArrayAccess|array $defaults
      * @param string|null $method
      * @param string|null $action
      *

--- a/src/Html.php
+++ b/src/Html.php
@@ -43,6 +43,9 @@ class Html
     /** @var \ArrayAccess|array */
     protected $model;
 
+    /** @var \ArrayAccess|array */
+    protected $defaults;
+
     public function __construct(Request $request)
     {
         $this->request = $request;
@@ -588,6 +591,52 @@ class Html
     }
 
     /**
+     * @param \ArrayAccess|array $model
+     *
+     * @return $this
+     */
+    public function defaults($defaults)
+    {
+        $this->defaults = $defaults;
+
+        return $this;
+    }
+
+    /**
+     * @param \ArrayAccess|array $model
+     * @param string|null $method
+     * @param string|null $action
+     *
+     * @return \Spatie\Html\Elements\Form
+     */
+    public function formWithDefaults($defaults, $method = 'POST', $action = null): Form
+    {
+        $this->defaults($defaults);
+
+        return $this->form($method, $action);
+    }
+
+    /**
+     * @return $this
+     */
+    public function endDefaults()
+    {
+        $this->defaults = null;
+
+        return $this;
+    }
+
+    /**
+     * @return \Illuminate\Contracts\Support\Htmlable
+     */
+    public function closeFormWithDefaults(): Htmlable
+    {
+        $this->endDefaults();
+
+        return $this->form()->close();
+    }
+
+    /**
      * @param string $name
      * @param mixed $value
      *
@@ -611,6 +660,10 @@ class Html
                 : $value;
         }
 
+        // use the default values
+        if (is_null($value) && $this->defaults && empty($this->request->old())) {
+            $value = data_get($this->defaults, $name);
+        }
         return $this->request->old($name, $value);
     }
 


### PR DESCRIPTION
Send an example. On this case i use with request. So if my request has ?status=1 it will prefill automatically

```
{{ html()->formWithDefaults(request()->all(), 'GET', request()->url())->open() }}
    <div class="mt-2 mb-4 flex gap-6 bg-slate-50 p-4 border border-gray-200 rounded-lg">
        {{ html()->select('status', [1 => 'Draft', 2 => 'Sent']) }}
        <div>
            {{ html()->submit(__('Search'))->class('bg-primary-600 text-white px-4 rounded mt-6 py-2 cursor-pointer') }}
        </div>
    </div>
{{ html()->closeFormWithDefaults() }}
```