### PR TITLE
Fix issues with boolean values

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -53,8 +53,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
      */
     public function attribute($attribute, $value = null)
     {
-        $element = clone $this;
-        
+        $element = clone $this; 
         $element->attributes->setAttribute($attribute, (string) $value);
 
         return $element;

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -54,6 +54,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     public function attribute($attribute, $value = null)
     {
         $element = clone $this; 
+        
         $element->attributes->setAttribute($attribute, (string) $value);
 
         return $element;

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -55,7 +55,7 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         $element = clone $this;
         
-        $element->attributes->setAttribute($attribute, $value);
+        $element->attributes->setAttribute($attribute, (string) $value);
 
         return $element;
     }

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -54,8 +54,6 @@ abstract class BaseElement implements Htmlable, HtmlElement
     public function attribute($attribute, $value = null)
     {
         $element = clone $this;
-
-        $value = is_bool($value) ? json_encode($value) : (string) $value;
         
         $element->attributes->setAttribute($attribute, $value);
 

--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -55,7 +55,9 @@ abstract class BaseElement implements Htmlable, HtmlElement
     {
         $element = clone $this;
 
-        $element->attributes->setAttribute($attribute, (string) $value);
+        $value = is_bool($value) ? json_encode($value) : (string) $value;
+        
+        $element->attributes->setAttribute($attribute, $value);
 
         return $element;
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -430,9 +430,11 @@ class Html
      */
     public function radio($name = null, $checked = null, $value = null)
     {        
+        $value_as_string = is_bool($value) ? json_encode($value) : $value;
+        
         return $this->input('radio', $name, $value)
-            ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug(is_bool($value) ? json_encode($value) : $value)))
-            ->attributeIf(! is_null($value), 'value', $value)
+            ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug($value_as_string)))
+            ->attributeIf(! is_null($value), 'value', $value_as_string)
             ->attributeIf((! is_null($value) && $this->old($name) === $value) || $checked, 'checked');
     }
 

--- a/src/Html.php
+++ b/src/Html.php
@@ -430,6 +430,8 @@ class Html
      */
     public function radio($name = null, $checked = null, $value = null)
     {
+        $value = is_bool($value) ? json_encode($value) : (string) $value;
+        
         return $this->input('radio', $name, $value)
             ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug($value)))
             ->attributeIf(! is_null($value), 'value', $value)

--- a/src/Html.php
+++ b/src/Html.php
@@ -429,11 +429,9 @@ class Html
      * @return \Spatie\Html\Elements\Input
      */
     public function radio($name = null, $checked = null, $value = null)
-    {
-        $value = is_bool($value) ? json_encode($value) : (string) $value;
-        
+    {        
         return $this->input('radio', $name, $value)
-            ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug($value)))
+            ->attributeIf($name, 'id', $value === null ? $name : ($name.'_'.Str::slug(is_bool($value) ? json_encode($value) : $value)))
             ->attributeIf(! is_null($value), 'value', $value)
             ->attributeIf((! is_null($value) && $this->old($name) === $value) || $checked, 'checked');
     }


### PR DESCRIPTION
This fixes an issue with boolean values on inputs. And more specifically if the value is false (boolean) the string casting ((string) $value) produces an empty string instead of 'false'. Moreover true produces '1' which is probably not the expected behavior when a user passes true as $value.

Even when a user try to avoid the issue by passing string values ('true', 'false'), if the model values passed through html()->model() are boolean then there are not auto-selected as the strict comparison of the values doesn't work.

This PR fixes the problem for all cases as long as are consistent with form values and model values.

Examples of current behavior:
```
// init with true value (boolean) - result: input with wrong value
html()->radio('test', null, true)   
<input type="radio" name="test" id="test_1" value="1">

// init with false value (boolean) - result: input with no value
html()->radio('test', null, false)
<input type="radio" name="test" id="test_" value>

// init with 'false' value (string) - result: no auto-selection (missing checked attribute)
html()->model(['test' => false])
html()->radio('test', null, 'false')
<input type="radio" name="test" id="test_false" value="false">
```

Examples of behavior after fix:

```
html()->radio('test', null, true)  
<input type="radio" name="test" id="test_true" value="true">

html()->radio('test', null, false)  
<input type="radio" name="test" id="test_false" value="false">

html()->model(['test' => false])
html()->radio('test', null, false)
<input type="radio" name="test" id="test_false" value="false" checked>
```


