### PR TITLE
Add support for multiples requests in the same process

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -37,15 +37,11 @@ class Html
     public const HTML_DATE_FORMAT = 'Y-m-d';
     public const HTML_TIME_FORMAT = 'H:i:s';
 
-    /** @var \Illuminate\Http\Request */
-    protected $request;
-
     /** @var \ArrayAccess|array */
     protected $model;
 
-    public function __construct(Request $request)
+    public function __construct()
     {
-        $this->request = $request;
     }
 
     /**
@@ -538,7 +534,7 @@ class Html
         return $this
             ->hidden()
             ->name('_token')
-            ->value($this->request->session()->token());
+            ->value(session()->token());
     }
 
     /**
@@ -605,13 +601,13 @@ class Html
         // If there's no default value provided, the html builder currently
         // has a model assigned and there aren't old input items,
         // try to retrieve a value from the model.
-        if (is_null($value) && $this->model && empty($this->request->old())) {
+        if (is_null($value) && $this->model && empty(request()->old())) {
             $value = ($value = data_get($this->model, $name)) instanceof UnitEnum
                 ? $this->getEnumValue($value)
                 : $value;
         }
 
-        return $this->request->old($name, $value);
+        return request()->old($name, $value);
     }
 
     /**


### PR DESCRIPTION
Good day, we are working with an app that works with the new Pest 4 Browser Plugin, but we're having troubles with this package. When we debugged, we found that the request is fixed when compiled the dependency container Laravel, and because we test a full walkthrough of an user in the app, the start request is not the same as the runtime request that the HTML builder need to evaluate.

Because in Laravel we don't have a equivalent to the `RequestStack` from Symfony to get the current request at runtime, we propose to use directly the helpers for the Laravel Framework.

As we could not found how to open an issue in this repository and we did not find how to report the problem, we decide to start a pull request. Sorry if that was not the correct approach.