### PR TITLE
make BaseElement::unless() compatible with Conditionable::unless()

### DIFF
--- a/src/BaseElement.php
+++ b/src/BaseElement.php
@@ -15,7 +15,9 @@ use Spatie\Html\Exceptions\MissingTag;
 
 abstract class BaseElement implements Htmlable, HtmlElement
 {
-    use Conditionable;
+    use Conditionable {
+        unless as trait_unless;
+    }
 
     use Macroable {
         __call as __macro_call;
@@ -332,13 +334,18 @@ abstract class BaseElement implements Htmlable, HtmlElement
      * Conditionally transform the element. Note that since elements are
      * immutable, you'll need to return a new instance from the callback.
      *
-     * @param bool $condition
-     * @param \Closure $callback
+     * @param mixed $condition
+     * @param callable $callback
+     * @param callable|null $default
      *
      * @return mixed
      */
-    public function unless(bool $condition, \Closure $callback)
+    public function unless($condition, callable $callback, callable|null $default = null)
     {
+        if (! is_bool($condition) || ! $callback instanceof \Closure || ! is_null($default)) {
+            return $this->trait_unless($condition, $callback, $default);
+        }
+
         return $this->if(! $condition, $callback);
     }
 


### PR DESCRIPTION
The addition of the `Conditionable` trait in #234 was not well thought out, because that trait includes an `unless()` method incompatible with the one already in the class. Since we can't remove the trait now, the next best thing is to alter the class method signature and pass things on to the trait method when needed.