### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2]
+        php: [8.5, 8.3, 8.2]
         laravel: ['10.*', '11.*', '12.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,27 +1,33 @@
 name: run-tests
 
-on:
-  - push
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        php: [8.5, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*']
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['13.*', '12.*', '11.*', '10.*']
+        stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 11.*
-            testbench: 9.*
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 10.*
+            testbench: 8.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
+          - laravel: 10.*
+            php: 8.5
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
@@ -36,8 +42,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/http": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.34|^3.7"
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.34|^3.7|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd">
   <testsuites>
     <testsuite name="Spatie Test Suite">
       <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
   <testsuites>
     <testsuite name="Spatie Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
 </phpunit>

--- a/src/Html.php
+++ b/src/Html.php
@@ -6,6 +6,7 @@ use BackedEnum;
 use DateTimeImmutable;
 use Exception;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -36,11 +37,14 @@ class Html
     public const HTML_DATE_FORMAT = 'Y-m-d';
     public const HTML_TIME_FORMAT = 'H:i:s';
 
+    protected ?Request $request;
+
     /** @var \ArrayAccess|array */
     protected $model;
 
-    public function __construct()
+    public function __construct(?Request $request = null)
     {
+        $this->request = $request;
     }
 
     /**
@@ -533,7 +537,7 @@ class Html
         return $this
             ->hidden()
             ->name('_token')
-            ->value(session()->token());
+            ->value(($this->request ?? request())->session()->token());
     }
 
     /**
@@ -600,13 +604,15 @@ class Html
         // If there's no default value provided, the html builder currently
         // has a model assigned and there aren't old input items,
         // try to retrieve a value from the model.
-        if (is_null($value) && $this->model && empty(request()->old())) {
+        $request = $this->request ?? request();
+
+        if (is_null($value) && $this->model && empty($request->old())) {
             $value = ($value = data_get($this->model, $name)) instanceof UnitEnum
                 ? $this->getEnumValue($value)
                 : $value;
         }
 
-        return request()->old($name, $value);
+        return $request->old($name, $value);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add Laravel 13 support
- Add PHP 8.5 to test matrix
- Fix coverage warnings
- Update test dependencies (Pest 4, PHPUnit 12, Testbench 11)